### PR TITLE
feat(marketplace): add agent leasing with expiration and permission gate

### DIFF
--- a/contracts/marketplace/src/manager.rs
+++ b/contracts/marketplace/src/manager.rs
@@ -1,0 +1,221 @@
+use soroban_sdk::{Address, BytesN, Env};
+
+use super::{
+    repository::LeaseRepository,
+    types::{LeaseError, LeaseTerm, LeaseStatus},
+};
+
+/// Minimum lease length in ledgers (~5 minutes at 5 s/ledger).
+const MIN_LEASE_DURATION_LEDGERS: u32 = 60;
+
+/// Encapsulates all lease business rules.
+///
+/// The manager is the single entry-point for contract methods and
+/// `ExecutionHub` permission checks. It delegates all storage I/O to
+/// `LeaseRepository` and never calls `env.storage()` directly.
+pub struct LeaseManager {
+    repo: LeaseRepository,
+    env: Env,
+}
+
+impl LeaseManager {
+    pub fn new(env: Env) -> Self {
+        Self {
+            repo: LeaseRepository::new(env.clone()),
+            env,
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Agent registration
+    // ------------------------------------------------------------------
+
+    /// Register `owner` as the lessor for `agent_id`.
+    ///
+    /// Should be called once when an agent is listed on the marketplace.
+    /// Returns `Unauthorized` if the agent is already registered to a
+    /// different address.
+    pub fn register_agent(
+        &self,
+        agent_id: &BytesN<32>,
+        owner: &Address,
+    ) -> Result<(), LeaseError> {
+        owner.require_auth();
+
+        if let Some(existing) = self.repo.load_agent_owner(agent_id) {
+            if &existing != owner {
+                return Err(LeaseError::Unauthorized);
+            }
+        }
+
+        self.repo.save_agent_owner(agent_id, owner);
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Lease lifecycle
+    // ------------------------------------------------------------------
+
+    /// Create a new lease granting `lessee` execution rights on `agent_id`
+    /// for the ledger range `[start_ledger, end_ledger)`.
+    ///
+    /// # Rules
+    /// * Caller must be the registered agent owner.
+    /// * `end_ledger > start_ledger + MIN_LEASE_DURATION_LEDGERS`.
+    /// * No active lease may already exist for the same `(agent_id, lessee)`.
+    pub fn create_lease(
+        &self,
+        agent_id: &BytesN<32>,
+        lessor: &Address,
+        lessee: &Address,
+        start_ledger: u32,
+        end_ledger: u32,
+    ) -> Result<LeaseTerm, LeaseError> {
+        lessor.require_auth();
+
+        // Ownership check
+        let owner = self
+            .repo
+            .load_agent_owner(agent_id)
+            .ok_or(LeaseError::Unauthorized)?;
+        if &owner != lessor {
+            return Err(LeaseError::Unauthorized);
+        }
+
+        // Duration guard
+        if end_ledger <= start_ledger
+            || (end_ledger - start_ledger) < MIN_LEASE_DURATION_LEDGERS
+        {
+            return Err(LeaseError::InvalidLeaseTerm);
+        }
+
+        // Duplicate guard: reject if an Active lease already exists
+        if let Some(existing) = self.repo.load_lease(agent_id, lessee) {
+            if existing.status == LeaseStatus::Active {
+                return Err(LeaseError::LeaseAlreadyExists);
+            }
+        }
+
+        let term = LeaseTerm {
+            lessor: lessor.clone(),
+            lessee: lessee.clone(),
+            start_ledger,
+            end_ledger,
+            status: LeaseStatus::Active,
+        };
+
+        self.repo.save_lease(agent_id, lessee, &term);
+        self.repo.increment_lease_count(agent_id);
+
+        Ok(term)
+    }
+
+    /// Revoke an active lease before it expires.
+    ///
+    /// Only the original lessor may revoke. The lease record is retained
+    /// with status `Revoked` for audit purposes.
+    pub fn revoke_lease(
+        &self,
+        agent_id: &BytesN<32>,
+        lessor: &Address,
+        lessee: &Address,
+    ) -> Result<(), LeaseError> {
+        lessor.require_auth();
+
+        let term = self
+            .repo
+            .load_lease(agent_id, lessee)
+            .ok_or(LeaseError::LeaseNotFound)?;
+
+        if &term.lessor != lessor {
+            return Err(LeaseError::Unauthorized);
+        }
+
+        self.repo.revoke_lease(agent_id, lessee);
+        Ok(())
+    }
+
+    /// Settle expiry for a lease whose `end_ledger` has passed.
+    ///
+    /// Anyone may call this to sync on-chain status; it is also called
+    /// lazily by `check_lease_permission` to keep status current.
+    pub fn settle_expiry(
+        &self,
+        agent_id: &BytesN<32>,
+        lessee: &Address,
+    ) -> Result<(), LeaseError> {
+        let term = self
+            .repo
+            .load_lease(agent_id, lessee)
+            .ok_or(LeaseError::LeaseNotFound)?;
+
+        let current = self.env.ledger().sequence();
+
+        if term.status == LeaseStatus::Active && current >= term.end_ledger {
+            self.repo.expire_lease(agent_id, lessee);
+        }
+
+        Ok(())
+    }
+
+    // ------------------------------------------------------------------
+    // Permission check — called by ExecutionHub
+    // ------------------------------------------------------------------
+
+    /// Returns `Ok(())` when `lessee` is permitted to execute `agent_id`
+    /// at the current ledger, applying lazy expiry settlement.
+    ///
+    /// # Errors
+    /// | Condition | Error |
+    /// |---|---|
+    /// | No lease on record | `LeaseNotFound` |
+    /// | Lease revoked | `LeaseRevoked` |
+    /// | `current_ledger >= end_ledger` | `LeaseExpired` |
+    /// | `current_ledger < start_ledger` | `LeaseExpired` (not yet active) |
+    pub fn check_lease_permission(
+        &self,
+        agent_id: &BytesN<32>,
+        lessee: &Address,
+    ) -> Result<(), LeaseError> {
+        let mut term = self
+            .repo
+            .load_lease(agent_id, lessee)
+            .ok_or(LeaseError::LeaseNotFound)?;
+
+        let current = self.env.ledger().sequence();
+
+        // Lazy expiry settlement
+        if term.status == LeaseStatus::Active && current >= term.end_ledger {
+            self.repo.expire_lease(agent_id, lessee);
+            term.status = LeaseStatus::Expired;
+        }
+
+        match term.status {
+            LeaseStatus::Revoked => Err(LeaseError::LeaseRevoked),
+            LeaseStatus::Expired => Err(LeaseError::LeaseExpired),
+            LeaseStatus::Active => {
+                if !term.is_valid_at(current) {
+                    Err(LeaseError::LeaseExpired)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Read-only queries
+    // ------------------------------------------------------------------
+
+    pub fn get_lease(
+        &self,
+        agent_id: &BytesN<32>,
+        lessee: &Address,
+    ) -> Option<LeaseTerm> {
+        self.repo.load_lease(agent_id, lessee)
+    }
+
+    pub fn get_lease_count(&self, agent_id: &BytesN<32>) -> u64 {
+        self.repo.get_lease_count(agent_id)
+    }
+}

--- a/contracts/marketplace/src/mod.rs
+++ b/contracts/marketplace/src/mod.rs
@@ -1,0 +1,40 @@
+/*!
+# Agent Leasing Module
+
+Provides time-bounded execution rights delegation for agents listed on
+the marketplace.
+
+## Architecture
+
+```
+LeaseManager          ← business logic, permission gate
+    └── LeaseRepository   ← storage I/O via StorageRepository<DataKey>
+            └── PersistentStorageRepository  (from common-utils)
+```
+
+## Typical flow
+
+```
+1. Agent owner calls `register_agent(agent_id, owner)`.
+2. Lessor calls `create_lease(agent_id, lessor, lessee, start, end)`.
+3. ExecutionHub calls `check_lease_permission(agent_id, lessee)` before
+   every execution — returns Ok or a typed LeaseError.
+4. On natural expiry `settle_expiry` is called lazily inside step 3.
+5. Lessor may call `revoke_lease` at any time to terminate early.
+```
+
+## Storage keys
+
+| Key | Tier | Description |
+|---|---|---|
+| `Lease(agent_id, lessee)` | Persistent | Full `LeaseTerm` struct |
+| `AgentOwner(agent_id)` | Persistent | Owner address |
+| `LeaseCount(agent_id)` | Persistent | Monotonic counter |
+*/
+
+pub mod manager;
+pub mod repository;
+pub mod types;
+
+pub use manager::LeaseManager;
+pub use types::{DataKey, LeaseError, LeaseTerm, LeaseStatus};

--- a/contracts/marketplace/src/repository.rs
+++ b/contracts/marketplace/src/repository.rs
@@ -1,0 +1,99 @@
+use soroban_sdk::{Address, BytesN, Env};
+
+use common_utils::{PersistentStorageRepository, StorageRepository};
+
+use super::types::{DataKey, LeaseTerm, LeaseStatus};
+
+/// TTL constants (in ledgers).
+///
+/// Soroban ledgers close roughly every 5 seconds, so:
+/// * `LEASE_TTL_THRESHOLD` ≈ 30 days of ledger time before auto-bump.
+/// * `LEASE_TTL_EXTEND`    ≈ 60 days – keeps lease record accessible for
+///   auditing even after expiry.
+const LEASE_TTL_THRESHOLD: u32 = 518_400;  // ~30 days
+const LEASE_TTL_EXTEND: u32    = 1_036_800; // ~60 days
+
+/// Handles all persistent-storage interactions for the leasing module.
+///
+/// Every method operates through `PersistentStorageRepository` so the
+/// business logic in `LeaseManager` never touches `env.storage()` directly.
+pub struct LeaseRepository {
+    repo: PersistentStorageRepository,
+}
+
+impl LeaseRepository {
+    pub fn new(env: Env) -> Self {
+        Self {
+            repo: PersistentStorageRepository::new(env),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // LeaseTerm CRUD
+    // ------------------------------------------------------------------
+
+    pub fn save_lease(&self, agent_id: &BytesN<32>, lessee: &Address, term: &LeaseTerm) {
+        let key = DataKey::Lease(agent_id.clone(), lessee.clone());
+        self.repo.set(&key, term);
+        self.repo.extend_ttl(&key, LEASE_TTL_THRESHOLD, LEASE_TTL_EXTEND);
+    }
+
+    pub fn load_lease(&self, agent_id: &BytesN<32>, lessee: &Address) -> Option<LeaseTerm> {
+        self.repo.get(&DataKey::Lease(agent_id.clone(), lessee.clone()))
+    }
+
+    pub fn lease_exists(&self, agent_id: &BytesN<32>, lessee: &Address) -> bool {
+        self.repo.has(&DataKey::Lease(agent_id.clone(), lessee.clone()))
+    }
+
+    // ------------------------------------------------------------------
+    // Mutation helpers
+    // ------------------------------------------------------------------
+
+    /// Mark a lease as `Expired` in storage (idempotent).
+    pub fn expire_lease(&self, agent_id: &BytesN<32>, lessee: &Address) {
+        if let Some(mut term) = self.load_lease(agent_id, lessee) {
+            term.status = LeaseStatus::Expired;
+            self.save_lease(agent_id, lessee, &term);
+        }
+    }
+
+    /// Mark a lease as `Revoked` in storage (idempotent).
+    pub fn revoke_lease(&self, agent_id: &BytesN<32>, lessee: &Address) {
+        if let Some(mut term) = self.load_lease(agent_id, lessee) {
+            term.status = LeaseStatus::Revoked;
+            self.save_lease(agent_id, lessee, &term);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Agent ownership
+    // ------------------------------------------------------------------
+
+    pub fn save_agent_owner(&self, agent_id: &BytesN<32>, owner: &Address) {
+        let key = DataKey::AgentOwner(agent_id.clone());
+        self.repo.set(&key, owner);
+        self.repo.extend_ttl(&key, LEASE_TTL_THRESHOLD, LEASE_TTL_EXTEND);
+    }
+
+    pub fn load_agent_owner(&self, agent_id: &BytesN<32>) -> Option<Address> {
+        self.repo.get(&DataKey::AgentOwner(agent_id.clone()))
+    }
+
+    // ------------------------------------------------------------------
+    // Lease counter (monotonic, used for analytics / indexing)
+    // ------------------------------------------------------------------
+
+    pub fn increment_lease_count(&self, agent_id: &BytesN<32>) -> u64 {
+        let key = DataKey::LeaseCount(agent_id.clone());
+        let count: u64 = self.repo.get(&key).unwrap_or(0);
+        let next = count + 1;
+        self.repo.set(&key, &next);
+        self.repo.extend_ttl(&key, LEASE_TTL_THRESHOLD, LEASE_TTL_EXTEND);
+        next
+    }
+
+    pub fn get_lease_count(&self, agent_id: &BytesN<32>) -> u64 {
+        self.repo.get(&DataKey::LeaseCount(agent_id.clone())).unwrap_or(0)
+    }
+}

--- a/contracts/marketplace/src/types.rs
+++ b/contracts/marketplace/src/types.rs
@@ -1,0 +1,94 @@
+use soroban_sdk::{contracttype, Address, BytesN};
+
+use common_utils::IStorageKey;
+
+// ---------------------------------------------------------------------------
+// LeaseStatus
+// ---------------------------------------------------------------------------
+
+/// Lifecycle state of a lease.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LeaseStatus {
+    /// Lease is active and the lessee may execute the agent.
+    Active,
+    /// Lease term has elapsed; execution is blocked.
+    Expired,
+    /// Lessor revoked the lease before expiry.
+    Revoked,
+}
+
+// ---------------------------------------------------------------------------
+// LeaseTerm
+// ---------------------------------------------------------------------------
+
+/// Full on-chain record of a single lease agreement.
+///
+/// Stored under `DataKey::Lease(agent_id, lessee)` in persistent storage.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LeaseTerm {
+    /// The address that owns the agent (lessor).
+    pub lessor: Address,
+    /// The address that has been granted temporary execution rights.
+    pub lessee: Address,
+    /// Soroban ledger sequence number when the lease becomes active.
+    pub start_ledger: u32,
+    /// Soroban ledger sequence number when the lease expires (exclusive).
+    pub end_ledger: u32,
+    /// Current lifecycle state.
+    pub status: LeaseStatus,
+}
+
+impl LeaseTerm {
+    /// Returns `true` when `current_ledger` is within the active window
+    /// and the lease has not been revoked.
+    pub fn is_valid_at(&self, current_ledger: u32) -> bool {
+        self.status == LeaseStatus::Active
+            && current_ledger >= self.start_ledger
+            && current_ledger < self.end_ledger
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DataKey
+// ---------------------------------------------------------------------------
+
+/// Storage keys for the marketplace leasing module.
+///
+/// All keys are scoped to `(agent_id, lessee)` pairs so multiple concurrent
+/// leases on the same agent are supported.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub enum DataKey {
+    /// The lease record for a specific `(agent_id, lessee)` pair.
+    Lease(BytesN<32>, Address),
+    /// Count of active leases ever created for an agent (monotonic).
+    LeaseCount(BytesN<32>),
+    /// The owner / lessor of an agent.
+    AgentOwner(BytesN<32>),
+}
+
+impl IStorageKey for DataKey {}
+
+// ---------------------------------------------------------------------------
+// LeaseError
+// ---------------------------------------------------------------------------
+
+/// Typed errors returned by leasing operations.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum LeaseError {
+    /// Caller is not the agent owner.
+    Unauthorized,
+    /// A lease already exists for this `(agent_id, lessee)` pair.
+    LeaseAlreadyExists,
+    /// No lease found for the `(agent_id, lessee)` pair.
+    LeaseNotFound,
+    /// The lease window is invalid (e.g. `end_ledger <= start_ledger`).
+    InvalidLeaseTerm,
+    /// The lease has expired.
+    LeaseExpired,
+    /// The lease was revoked by the lessor.
+    LeaseRevoked,
+}


### PR DESCRIPTION
Closes #13

Implements lease-based execution rights delegation for marketplace agents.

## Changes
- Add `LeaseTerm` struct and `LeaseStatus` enum (Active / Expired / Revoked)
- Add `DataKey` enum with IStorageKey for lease storage keys
- Add `LeaseRepository` wrapping PersistentStorageRepository for all lease I/O
- Add `LeaseManager` with full lease lifecycle: create, revoke, settle_expiry
- Add `check_lease_permission` as the ExecutionHub permission gate — enforces
  lease-only access with lazy expiry settlement on every execution attempt
- No direct env.storage() calls in business logic; all I/O via repository layer

## Enforcement rules
- Minimum lease duration: 60 ledgers
- Duplicate active leases on same (agent_id, lessee) pair are rejected
- Only the registered lessor may create or revoke a lease
- Expiry is settled lazily on permission check; also callable explicitly

## Testing
cargo test --package marketplace --lib leasing