### PR TITLE
feat: KYC state machine, governance multipliers, referral rewards (#135 #136 #147 #148)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
     "contracts/governance",
     "contracts/staking-bonuses",
+    "contracts/compliance-integration",
+    "contracts/referral-rewards",
     "lib",
     "shared",
 ]

--- a/contracts/compliance-integration/src/lib.rs
+++ b/contracts/compliance-integration/src/lib.rs
@@ -27,7 +27,40 @@ pub enum Error {
     ReviewNotFound = 12,
     RateLimitExceeded = 13,
     AuditRequired = 14,
+    // KYC state machine errors
+    KycSubjectNotFound = 15,
+    KycInvalidTransition = 16,
+    KycTerminalState = 17,
 }
+
+// ── KYC State Machine (issues #147 & #148) ──────────────────────────────────
+
+/// KYC lifecycle states.
+/// Valid transitions: Pending → InReview → Verified
+///                   Pending → InReview → Rejected
+/// Terminal states (Verified, Rejected) are immutable except via governance override.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[contracttype]
+#[repr(u32)]
+pub enum KycStatus {
+    Pending = 0,
+    InReview = 1,
+    Verified = 2,
+    Rejected = 3,
+}
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct KycRecord {
+    pub subject_did: String,
+    pub status: KycStatus,
+    pub updated_by: Address,
+    pub updated_at: u64,
+    /// Set when status reaches a terminal state (Verified / Rejected).
+    pub finalized_at: Option<u64>,
+}
+
+const KYC_RECORDS: Symbol = symbol_short!("kyc_rec");
 
 // Contract events
 #[contracttype]
@@ -589,5 +622,288 @@ impl ComplianceIntegrationContract {
         let new_count = count + 1;
         env.storage().instance().set(counter_key, &new_count);
         new_count
+    }
+
+    // ── KYC State Machine ────────────────────────────────────────────────────
+
+    /// Initialise a KYC record for a subject DID (starts in Pending).
+    pub fn kyc_init(env: Env, operator: Address, subject_did: String) -> Result<(), Error> {
+        admin::verify_admin(&env, &operator).map_err(|_| Error::Unauthorized)?;
+        let key = (KYC_RECORDS, subject_did.clone());
+        if env.storage().instance().has(&key) {
+            return Err(Error::DuplicateReport);
+        }
+        let now = env.ledger().timestamp();
+        let record = KycRecord {
+            subject_did: subject_did.clone(),
+            status: KycStatus::Pending,
+            updated_by: operator.clone(),
+            updated_at: now,
+            finalized_at: None,
+        };
+        env.storage().instance().set(&key, &record);
+        env.events().publish(
+            (Symbol::new(&env, "kyc"), Symbol::new(&env, "init")),
+            (subject_did, KycStatus::Pending),
+        );
+        Ok(())
+    }
+
+    /// Advance the KYC state following the strict transition table.
+    /// Allowed: Pending→InReview, InReview→Verified, InReview→Rejected.
+    /// Terminal states (Verified, Rejected) are immutable without governance override.
+    pub fn kyc_transition(
+        env: Env,
+        operator: Address,
+        subject_did: String,
+        new_status: KycStatus,
+    ) -> Result<(), Error> {
+        admin::verify_admin(&env, &operator).map_err(|_| Error::Unauthorized)?;
+        let key = (KYC_RECORDS, subject_did.clone());
+        let mut record: KycRecord = env
+            .storage()
+            .instance()
+            .get(&key)
+            .ok_or(Error::KycSubjectNotFound)?;
+
+        // Reject mutations of terminal states (issue #147).
+        if record.status == KycStatus::Verified || record.status == KycStatus::Rejected {
+            return Err(Error::KycTerminalState);
+        }
+
+        // Enforce strict ordering (issue #148).
+        let allowed = matches!(
+            (record.status, new_status),
+            (KycStatus::Pending, KycStatus::InReview)
+                | (KycStatus::InReview, KycStatus::Verified)
+                | (KycStatus::InReview, KycStatus::Rejected)
+        );
+        if !allowed {
+            return Err(Error::KycInvalidTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        let is_terminal =
+            new_status == KycStatus::Verified || new_status == KycStatus::Rejected;
+        record.status = new_status;
+        record.updated_by = operator.clone();
+        record.updated_at = now;
+        if is_terminal {
+            record.finalized_at = Some(now);
+        }
+        env.storage().instance().set(&key, &record);
+        env.events().publish(
+            (Symbol::new(&env, "kyc"), Symbol::new(&env, "transition")),
+            (subject_did, new_status),
+        );
+        Ok(())
+    }
+
+    /// Governance-approved override to reset a terminal KYC state.
+    /// Requires admin (governance role) and resets to Pending.
+    pub fn kyc_governance_override(
+        env: Env,
+        governance: Address,
+        subject_did: String,
+    ) -> Result<(), Error> {
+        admin::verify_admin(&env, &governance).map_err(|_| Error::Unauthorized)?;
+        let key = (KYC_RECORDS, subject_did.clone());
+        let mut record: KycRecord = env
+            .storage()
+            .instance()
+            .get(&key)
+            .ok_or(Error::KycSubjectNotFound)?;
+        let now = env.ledger().timestamp();
+        record.status = KycStatus::Pending;
+        record.updated_by = governance.clone();
+        record.updated_at = now;
+        record.finalized_at = None;
+        env.storage().instance().set(&key, &record);
+        env.events().publish(
+            (Symbol::new(&env, "kyc"), Symbol::new(&env, "override")),
+            (subject_did, KycStatus::Pending),
+        );
+        Ok(())
+    }
+
+    /// Read the current KYC record for a subject.
+    pub fn kyc_get(env: Env, subject_did: String) -> Result<KycRecord, Error> {
+        let key = (KYC_RECORDS, subject_did);
+        env.storage()
+            .instance()
+            .get(&key)
+            .ok_or(Error::KycSubjectNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        symbol_short,
+        testutils::Address as _,
+        Address, Env, String,
+    };
+
+    fn setup(env: &Env) -> (Address, Address) {
+        let contract_id = env.register_contract(None, ComplianceIntegrationContract);
+        let admin = Address::generate(env);
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("admin"), &admin);
+        });
+        (contract_id, admin)
+    }
+
+    #[test]
+    fn test_kyc_valid_transitions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin) = setup(&env);
+        let subject = String::from_str(&env, "did:stellar:subject1");
+
+        env.as_contract(&contract_id, || {
+            ComplianceIntegrationContract::kyc_init(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+            )
+            .unwrap();
+
+            let rec = ComplianceIntegrationContract::kyc_get(env.clone(), subject.clone()).unwrap();
+            assert_eq!(rec.status, KycStatus::Pending);
+
+            ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::InReview,
+            )
+            .unwrap();
+
+            ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::Verified,
+            )
+            .unwrap();
+
+            let rec = ComplianceIntegrationContract::kyc_get(env.clone(), subject.clone()).unwrap();
+            assert_eq!(rec.status, KycStatus::Verified);
+            assert!(rec.finalized_at.is_some());
+        });
+    }
+
+    #[test]
+    fn test_kyc_skip_transition_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin) = setup(&env);
+        let subject = String::from_str(&env, "did:stellar:subject2");
+
+        env.as_contract(&contract_id, || {
+            ComplianceIntegrationContract::kyc_init(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+            )
+            .unwrap();
+
+            // Skipping InReview → should fail (issue #148)
+            let err = ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::Verified,
+            )
+            .unwrap_err();
+            assert_eq!(err, Error::KycInvalidTransition);
+        });
+    }
+
+    #[test]
+    fn test_kyc_terminal_state_immutable() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin) = setup(&env);
+        let subject = String::from_str(&env, "did:stellar:subject3");
+
+        env.as_contract(&contract_id, || {
+            ComplianceIntegrationContract::kyc_init(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+            )
+            .unwrap();
+            ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::InReview,
+            )
+            .unwrap();
+            ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::Rejected,
+            )
+            .unwrap();
+
+            // Attempt to mutate terminal state → must fail (issue #147)
+            let err = ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::Pending,
+            )
+            .unwrap_err();
+            assert_eq!(err, Error::KycTerminalState);
+        });
+    }
+
+    #[test]
+    fn test_kyc_governance_override() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin) = setup(&env);
+        let subject = String::from_str(&env, "did:stellar:subject4");
+
+        env.as_contract(&contract_id, || {
+            ComplianceIntegrationContract::kyc_init(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+            )
+            .unwrap();
+            ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::InReview,
+            )
+            .unwrap();
+            ComplianceIntegrationContract::kyc_transition(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+                KycStatus::Verified,
+            )
+            .unwrap();
+
+            // Governance override resets terminal state
+            ComplianceIntegrationContract::kyc_governance_override(
+                env.clone(),
+                admin.clone(),
+                subject.clone(),
+            )
+            .unwrap();
+
+            let rec = ComplianceIntegrationContract::kyc_get(env.clone(), subject.clone()).unwrap();
+            assert_eq!(rec.status, KycStatus::Pending);
+            assert!(rec.finalized_at.is_none());
+        });
     }
 }

--- a/contracts/staking-bonuses/src/lib.rs
+++ b/contracts/staking-bonuses/src/lib.rs
@@ -31,6 +31,15 @@ const LOCK_PERIOD_SECONDS: u64 = 7 * DAY_IN_SECONDS;
 const REWARD_PERIOD_SECONDS: u64 = 30 * DAY_IN_SECONDS;
 const BONUS_PERCENT_PER_MONTH: i128 = 5;
 
+/// Governance vote count thresholds for multiplier tiers (issue #136).
+/// Stakers who have cast ≥ threshold votes in the last month receive the multiplier.
+const MULTIPLIER_TIER1_VOTES: u32 = 1;  // ≥1 vote  → 1.25× (125 bps)
+const MULTIPLIER_TIER2_VOTES: u32 = 5;  // ≥5 votes → 1.50× (150 bps)
+const MULTIPLIER_TIER3_VOTES: u32 = 10; // ≥10 votes → 2.00× (200 bps)
+
+/// Storage key for per-user governance vote count (set by governance contract or admin).
+const GOV_VOTES_KEY: &str = "gov_votes";
+
 #[contractimpl]
 impl StakingBonuses {
     /// Initialize the contract with an admin address.
@@ -43,6 +52,52 @@ impl StakingBonuses {
             .instance()
             .set(&Symbol::new(&env, ADMIN_KEY), &admin_addr);
         Ok(())
+    }
+
+    /// Record governance participation for a user (called by admin / governance contract).
+    /// `vote_count` is the number of governance votes cast in the current monthly window.
+    pub fn record_governance_votes(
+        env: Env,
+        caller: Address,
+        user: Address,
+        vote_count: u32,
+    ) -> Result<(), ContractError> {
+        // Only admin may update governance vote counts.
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, ADMIN_KEY))
+            .ok_or(ContractError::Unauthorized)?;
+        if caller != admin {
+            return Err(ContractError::Unauthorized);
+        }
+        caller.require_auth();
+        let key = (Symbol::new(&env, GOV_VOTES_KEY), user.clone());
+        env.storage().instance().set(&key, &vote_count);
+        env.events().publish(
+            (
+                Symbol::new(&env, "staking"),
+                Symbol::new(&env, "gov_votes_recorded"),
+            ),
+            (user, vote_count),
+        );
+        Ok(())
+    }
+
+    /// Return the governance-activity multiplier for a user in basis points (100 = 1×).
+    /// Tier 1 (≥1 vote): 125 bps, Tier 2 (≥5 votes): 150 bps, Tier 3 (≥10 votes): 200 bps.
+    pub fn get_governance_multiplier(env: Env, user: Address) -> u32 {
+        let key = (Symbol::new(&env, GOV_VOTES_KEY), user);
+        let votes: u32 = env.storage().instance().get(&key).unwrap_or(0);
+        if votes >= MULTIPLIER_TIER3_VOTES {
+            200
+        } else if votes >= MULTIPLIER_TIER2_VOTES {
+            150
+        } else if votes >= MULTIPLIER_TIER1_VOTES {
+            125
+        } else {
+            100
+        }
     }
 
     /// Stake a specific token on behalf of `user`.
@@ -68,7 +123,7 @@ impl StakingBonuses {
             earned: 0,
         });
 
-        Self::accrue_rewards(&mut info, now)?;
+        Self::accrue_rewards(&env, &mut info, now, &user)?;
 
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&user, &env.current_contract_address(), &amount);
@@ -99,7 +154,7 @@ impl StakingBonuses {
             None => return 0,
         };
 
-        Self::accrue_rewards(&mut info, env.ledger().timestamp()).unwrap_or(());
+        Self::accrue_rewards(&env, &mut info, env.ledger().timestamp(), &user).unwrap_or(());
         info.earned
     }
 
@@ -110,7 +165,7 @@ impl StakingBonuses {
         let now = env.ledger().timestamp();
         let key = Self::stake_key(&user, &token);
         let mut info = Self::load_stake(&env, &key).ok_or(ContractError::StakeNotFound)?;
-        Self::accrue_rewards(&mut info, now)?;
+        Self::accrue_rewards(&env, &mut info, now, &user)?;
 
         let bonus = info.earned;
         info.earned = 0;
@@ -139,7 +194,7 @@ impl StakingBonuses {
             return Err(ContractError::StakeLocked);
         }
 
-        Self::accrue_rewards(&mut info, now)?;
+        Self::accrue_rewards(&env, &mut info, now, &user)?;
 
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&env.current_contract_address(), &user, &info.amt);
@@ -173,7 +228,12 @@ impl StakingBonuses {
         env.storage().instance().get(key)
     }
 
-    fn accrue_rewards(info: &mut StakeInfo, now: u64) -> Result<(), ContractError> {
+    fn accrue_rewards(
+        env: &Env,
+        info: &mut StakeInfo,
+        now: u64,
+        user: &Address,
+    ) -> Result<(), ContractError> {
         let elapsed = now.saturating_sub(info.last_ts);
         let periods = elapsed / REWARD_PERIOD_SECONDS;
         if periods == 0 {
@@ -181,13 +241,17 @@ impl StakingBonuses {
         }
 
         let periods_i = periods as i128;
+        // Apply governance multiplier (basis points, 100 = 1×).
+        let multiplier = Self::get_governance_multiplier(env.clone(), user.clone()) as i128;
         let reward = info
             .amt
             .checked_mul(BONUS_PERCENT_PER_MONTH)
             .ok_or(ContractError::OverflowError)?
             .checked_mul(periods_i)
             .ok_or(ContractError::OverflowError)?
-            .checked_div(100)
+            .checked_mul(multiplier)
+            .ok_or(ContractError::OverflowError)?
+            .checked_div(100 * 100) // percent × bps
             .ok_or(ContractError::OverflowError)?;
 
         info.earned = info
@@ -301,6 +365,7 @@ mod tests {
 
         env.ledger().set_timestamp(31 * DAY_IN_SECONDS);
 
+        // No governance votes → 100 bps multiplier → 5% * 100/100 = 5%
         assert_eq!(client.calculate_bonus(&user, &token_a), 50);
         assert_eq!(client.calculate_bonus(&user, &token_b), 100);
 
@@ -329,5 +394,58 @@ mod tests {
 
         assert_eq!(client.get_stake_info(&user, &token_a), None);
         assert_eq!(client.get_stake_info(&user, &token_b), None);
+    }
+
+    #[test]
+    fn test_governance_multiplier_tiers() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        let contract_id = env.register_contract(None, StakingBonuses);
+        let client = StakingBonusesClient::new(&env, &contract_id);
+        client.init_contract(&admin);
+
+        // No votes → base multiplier 100 bps
+        assert_eq!(client.get_governance_multiplier(&user), 100);
+
+        // 1 vote → tier 1: 125 bps
+        client.record_governance_votes(&admin, &user, &1);
+        assert_eq!(client.get_governance_multiplier(&user), 125);
+
+        // 5 votes → tier 2: 150 bps
+        client.record_governance_votes(&admin, &user, &5);
+        assert_eq!(client.get_governance_multiplier(&user), 150);
+
+        // 10 votes → tier 3: 200 bps
+        client.record_governance_votes(&admin, &user, &10);
+        assert_eq!(client.get_governance_multiplier(&user), 200);
+    }
+
+    #[test]
+    fn test_governance_multiplier_applied_to_rewards() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+        let token = setup_token(&env, &admin);
+        let token_client = MockTokenClient::new(&env, &token);
+        token_client.mint(&user, &10_000);
+
+        let contract_id = env.register_contract(None, StakingBonuses);
+        let client = StakingBonusesClient::new(&env, &contract_id);
+        client.init_contract(&admin);
+
+        // Give user tier-3 multiplier (200 bps = 2×)
+        client.record_governance_votes(&admin, &user, &10);
+
+        client.stake(&user, &token, &1_000);
+        env.ledger().set_timestamp(31 * DAY_IN_SECONDS);
+
+        // 5% * 2× = 10% of 1000 = 100
+        assert_eq!(client.calculate_bonus(&user, &token), 100);
     }
 }


### PR DESCRIPTION
## Summary

Resolves all 4 issues assigned to @Xhristin3 in a single PR.

Closes #135
Closes #136
Closes #147
Closes #148

---

## Issue #147 — Enforce KYC State Immutability After Verification Completion

Added a strict KYC state machine to `contracts/compliance-integration`:

- `KycStatus` enum: `Pending`, `InReview`, `Verified`, `Rejected`
- Terminal states (`Verified`, `Rejected`) are immutable — any further `kyc_transition` call returns `KycTerminalState` error
- `finalized_at` timestamp stored when a terminal state is reached
- `kyc_governance_override` allows an authorized governance/admin role to reset a terminal state back to `Pending`

## Issue #148 — Validate KYC State Transition Order and Reject Invalid Sequences

Strict transition table enforced in `kyc_transition`:

| From | To | Allowed |
|---|---|---|
| Pending | InReview | ✅ |
| InReview | Verified | ✅ |
| InReview | Rejected | ✅ |
| Any other | Any | ❌ `KycInvalidTransition` |

4 unit tests cover: valid full path, skip-state rejection, terminal immutability, governance override.

## Issue #136 — Bonus Multipliers for Active Stakers

Added governance-vote-based multiplier tiers to `contracts/staking-bonuses`:

| Monthly governance votes | Multiplier |
|---|---|
| 0 | 1.00× (base) |
| ≥ 1 | 1.25× |
| ≥ 5 | 1.50× |
| ≥ 10 | 2.00× |

- `record_governance_votes(admin, user, count)` — admin updates participation data monthly
- `get_governance_multiplier(user)` — public query
- Multiplier applied automatically in `accrue_rewards`
- Tests for all tiers and reward calculation with 2× multiplier

## Issue #135 — Referral Program for Escrow

The `contracts/referral-rewards` contract was already implemented with:
- `register_referral` — unique per-user referral tracking
- `add_reward` — admin-authorized reward crediting
- `claim_rewards` — referrer claims accumulated balance
- `get_referral_count` / `get_pending_rewards` — query functions

Added `referral-rewards` and `compliance-integration` to the workspace `Cargo.toml` so both contracts are included in CI clippy/fmt checks.

## CI Impact

- `cargo fmt -- --check`: all new code is formatted
- `cargo clippy`: no new warnings (uses `matches!` macro, no dead-code paths)
- `cargo build governance`: unchanged, still builds
- `cargo test -p staking-bonuses`: new multiplier tests pass