### PR TITLE
feat(agent-nft): add ownership history tracking for provenance

### DIFF
--- a/contracts/agent-nft/src/lib.rs
+++ b/contracts/agent-nft/src/lib.rs
@@ -11,8 +11,8 @@ use stellai_lib::{
     audit::{create_audit_log, OperationType},
     errors::ContractError,
     rbac,
-    storage_keys::{AGENT_COUNTER_KEY, APPROVED_MINTERS_KEY},
-    types::{Agent, OptionalRoyaltyInfo, RoyaltyInfo},
+    storage_keys::{AGENT_COUNTER_KEY, APPROVED_MINTERS_KEY, OWNERSHIP_HISTORY_KEY_PREFIX},
+    types::{Agent, OptionalRoyaltyInfo, OwnerRecord, RoyaltyInfo},
     validation, ADMIN_KEY,
 };
 
@@ -112,6 +112,23 @@ impl AgentNFT {
     /// Helper to get storage key for agent royalty info
     fn get_royalty_key(env: &Env, agent_id: u64) -> (Symbol, u64) {
         (Symbol::new(env, "royalty"), agent_id)
+    }
+
+    /// Helper to get storage key for agent ownership history
+    fn get_ownership_history_key(env: &Env, agent_id: u64) -> (Symbol, u64) {
+        (Symbol::new(env, OWNERSHIP_HISTORY_KEY_PREFIX), agent_id)
+    }
+
+    /// Append an OwnerRecord to the ownership history for an agent (append-only, no removal)
+    fn append_owner_record(env: &Env, agent_id: u64, record: OwnerRecord) {
+        let key = Self::get_ownership_history_key(env, agent_id);
+        let mut history: Vec<OwnerRecord> = env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        history.push_back(record);
+        env.storage().instance().set(&key, &history);
     }
 
     /// Validate royalty fee is within acceptable bounds
@@ -262,6 +279,16 @@ impl AgentNFT {
         // Initialize lease status to false (not leased)
         Self::set_agent_lease_status(&env, agent_id_u64, false);
 
+        // Record original minter as the first ownership history entry (provenance)
+        Self::append_owner_record(
+            &env,
+            agent_id_u64,
+            OwnerRecord {
+                owner: owner.clone(),
+                acquired_at: env.ledger().timestamp(),
+            },
+        );
+
         // Emit AgentMinted event
         env.events().publish(
             (Symbol::new(&env, "agent_nft"), AgentEvent::AgentMinted),
@@ -362,6 +389,16 @@ impl AgentNFT {
 
         // Initialize lease status
         Self::set_agent_lease_status(&env, agent_id, false);
+
+        // Record original minter as the first ownership history entry (provenance)
+        Self::append_owner_record(
+            &env,
+            agent_id,
+            OwnerRecord {
+                owner: owner.clone(),
+                acquired_at: env.ledger().timestamp(),
+            },
+        );
 
         // Store royalty info if provided
         if let (Some(recipient), Some(fee)) = (royalty_recipient, royalty_fee) {
@@ -539,6 +576,16 @@ impl AgentNFT {
 
         env.storage().instance().set(&key, &agent);
 
+        // Record new owner in provenance history
+        Self::append_owner_record(
+            &env,
+            agent_id,
+            OwnerRecord {
+                owner: to.clone(),
+                acquired_at: env.ledger().timestamp(),
+            },
+        );
+
         env.events().publish(
             (Symbol::new(&env, "agent_nft"), AgentEvent::AgentTransferred),
             (agent_id, previous_owner.clone(), to.clone()),
@@ -633,6 +680,16 @@ impl AgentNFT {
             let key = Self::get_agent_key(&env, agent_id);
             env.storage().instance().set(&key, &agent);
             Self::set_agent_lease_status(&env, agent_id, false);
+
+            // Record original minter as first ownership history entry (provenance)
+            Self::append_owner_record(
+                &env,
+                agent_id,
+                OwnerRecord {
+                    owner: data.owner.clone(),
+                    acquired_at: env.ledger().timestamp(),
+                },
+            );
 
             // Handle Royalty if present
             if let OptionalRoyaltyInfo::Some(royalty) = data.royalty {
@@ -815,6 +872,34 @@ impl AgentNFT {
 
         let royalty_key = Self::get_royalty_key(&env, agent_id);
         Ok(env.storage().instance().get(&royalty_key))
+    }
+
+    /// Get the full ownership history (provenance chain) for an agent.
+    /// Records are ordered from original minter to most recent owner.
+    ///
+    /// # Arguments
+    /// * `agent_id` - The agent ID to query
+    ///
+    /// # Returns
+    /// Result<Vec<OwnerRecord>, ContractError>
+    ///
+    /// # Errors
+    /// - ContractError::InvalidAgentId if agent_id is 0
+    /// - ContractError::AgentNotFound if the agent does not exist
+    pub fn get_ownership_history(env: Env, agent_id: u64) -> Result<Vec<OwnerRecord>, ContractError> {
+        if agent_id == 0 {
+            return Err(ContractError::InvalidAgentId);
+        }
+        // Verify agent exists
+        if !Self::agent_exists(&env, agent_id) {
+            return Err(ContractError::AgentNotFound);
+        }
+        let key = Self::get_ownership_history_key(&env, agent_id);
+        Ok(env
+            .storage()
+            .instance()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env)))
     }
 }
 

--- a/contracts/agent-nft/src/test.rs
+++ b/contracts/agent-nft/src/test.rs
@@ -478,4 +478,154 @@ mod prop_tests {
         assert_eq!(client.total_agents(), 0u64);
         assert!(client.try_get_agent(&1).is_err());
     }
+
+    // ── Ownership History / Provenance Tests (Issue #238) ───────────────────
+
+    #[test]
+    fn test_ownership_history_records_minter_on_mint() {
+        let env = Env::default();
+        let (client, admin) = setup_contract(&env);
+        let owner = Address::generate(&env);
+        client.add_approved_minter(&admin, &owner);
+        env.mock_all_auths();
+
+        mint_test_agent(&env, &client, &owner, 1, "QmProvenanceMint1", 1);
+
+        let history = client.get_ownership_history(&1);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).unwrap().owner, owner);
+    }
+
+    #[test]
+    fn test_ownership_history_grows_on_each_transfer() {
+        let env = Env::default();
+        let (client, admin) = setup_contract(&env);
+        let owner1 = Address::generate(&env);
+        let owner2 = Address::generate(&env);
+        let owner3 = Address::generate(&env);
+        client.add_approved_minter(&admin, &owner1);
+        env.mock_all_auths();
+
+        mint_test_agent(&env, &client, &owner1, 1, "QmProvenanceTransfer1", 1);
+
+        client.transfer_agent(&1, &owner1, &owner2);
+        client.transfer_agent(&1, &owner2, &owner3);
+
+        let history = client.get_ownership_history(&1);
+        // 1 (mint) + 2 transfers = 3 entries
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(0).unwrap().owner, owner1);
+        assert_eq!(history.get(1).unwrap().owner, owner2);
+        assert_eq!(history.get(2).unwrap().owner, owner3);
+    }
+
+    #[test]
+    fn test_ownership_history_traceable_to_original_minter() {
+        let env = Env::default();
+        let (client, admin) = setup_contract(&env);
+        let minter = Address::generate(&env);
+        let buyer1 = Address::generate(&env);
+        let buyer2 = Address::generate(&env);
+        client.add_approved_minter(&admin, &minter);
+        env.mock_all_auths();
+
+        mint_test_agent(&env, &client, &minter, 1, "QmProvenance_chain", 1);
+        client.transfer_agent(&1, &minter, &buyer1);
+        client.transfer_agent(&1, &buyer1, &buyer2);
+
+        let history = client.get_ownership_history(&1);
+        // Original minter is always the first entry
+        assert_eq!(history.get(0).unwrap().owner, minter);
+        // Current owner is the last entry
+        assert_eq!(history.get(history.len() - 1).unwrap().owner, buyer2);
+    }
+
+    #[test]
+    fn test_ownership_history_not_found_for_nonexistent_agent() {
+        let env = Env::default();
+        let (client, _admin) = setup_contract(&env);
+
+        let result = client.try_get_ownership_history(&999);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ownership_history_invalid_agent_id_zero() {
+        let env = Env::default();
+        let (client, _admin) = setup_contract(&env);
+
+        let result = client.try_get_ownership_history(&0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ownership_history_records_minter_via_legacy_mint() {
+        let env = Env::default();
+        let (client, admin) = setup_contract(&env);
+        let owner = Address::generate(&env);
+        client.add_approved_minter(&admin, &owner);
+        env.mock_all_auths();
+
+        let agent_id = client.mint_agent_legacy(
+            &owner,
+            &String::from_str(&env, "LegacyAgent"),
+            &String::from_str(&env, "hash123"),
+            &Vec::new(&env),
+            &None,
+            &None,
+        );
+
+        let history = client.get_ownership_history(&agent_id);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).unwrap().owner, owner);
+    }
+
+    #[test]
+    fn test_ownership_history_records_minter_via_batch_mint() {
+        let env = Env::default();
+        let (client, admin) = setup_contract(&env);
+        env.mock_all_auths();
+        client.add_approved_minter(&admin, &admin);
+
+        let batch_owner = Address::generate(&env);
+        let data = AgentMintData {
+            owner: batch_owner.clone(),
+            name: String::from_str(&env, "BatchAgent"),
+            model_hash: String::from_str(&env, "hash"),
+            metadata_cid: String::from_str(&env, "QmBatchProvenance"),
+            capabilities: Vec::new(&env),
+            royalty: stellai_lib::types::OptionalRoyaltyInfo::None,
+        };
+        let ids = client.batch_mint(&admin, &soroban_sdk::vec![&env, data]);
+        let agent_id = ids.get(0).unwrap();
+
+        let history = client.get_ownership_history(&agent_id);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).unwrap().owner, batch_owner);
+    }
+
+    #[test]
+    fn test_ownership_history_multiple_agents_independent() {
+        let env = Env::default();
+        let (client, admin) = setup_contract(&env);
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+        let new_owner_a = Address::generate(&env);
+        client.add_approved_minter(&admin, &owner_a);
+        client.add_approved_minter(&admin, &owner_b);
+        env.mock_all_auths();
+
+        mint_test_agent(&env, &client, &owner_a, 1, "QmAgentA", 1);
+        mint_test_agent(&env, &client, &owner_b, 2, "QmAgentB", 1);
+
+        client.transfer_agent(&1, &owner_a, &new_owner_a);
+
+        let history_a = client.get_ownership_history(&1);
+        let history_b = client.get_ownership_history(&2);
+
+        // Agent A has 2 entries; agent B remains at 1
+        assert_eq!(history_a.len(), 2);
+        assert_eq!(history_b.len(), 1);
+        assert_eq!(history_b.get(0).unwrap().owner, owner_b);
+    }
 }

--- a/lib/src/storage_keys.rs
+++ b/lib/src/storage_keys.rs
@@ -12,6 +12,7 @@ pub const PROVIDER_LIST_KEY: &str = "providers";
 pub const AGENT_COUNTER_KEY: &str = "agent_counter";
 pub const AGENT_KEY_PREFIX: &str = "agent_";
 pub const AGENT_LEASE_STATUS_PREFIX: &str = "agent_lease_";
+pub const OWNERSHIP_HISTORY_KEY_PREFIX: &str = "own_hist_";
 pub const APPROVED_MINTERS_KEY: &str = "approved_minters";
 pub const IMPLEMENTATION_KEY: Symbol = symbol_short!("impl_key");
 pub const UPGRADE_HISTORY_KEY: Symbol = symbol_short!("up_hist");

--- a/lib/src/types.rs
+++ b/lib/src/types.rs
@@ -209,6 +209,14 @@ pub struct RoyaltyPaymentRecord {
     pub asset_class: AssetClass,
 }
 
+/// A single record in an agent's ownership history (provenance chain)
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[contracttype]
+pub struct OwnerRecord {
+    pub owner: Address,
+    pub acquired_at: u64, // ledger timestamp when this owner acquired the agent
+}
+
 /// Wrapper enum so Option<RoyaltyInfo> works inside contracttype structs
 #[derive(Clone, Debug)]
 #[contracttype]


### PR DESCRIPTION
## Summary

Implements full chain-of-custody tracking for agent NFTs, resolving #238.

## Changes

- **`OwnerRecord` type** added to `stellai_lib` — stores `owner: Address` and `acquired_at: u64` (ledger timestamp)
- **`OWNERSHIP_HISTORY_KEY_PREFIX`** storage key constant added
- **`append_owner_record`** private helper — append-only, no removal (tamper-proof)
- **`get_ownership_history`** public query — returns full `Vec<OwnerRecord>` for any agent
- Original minter recorded as first entry on `mint_agent`, `mint_agent_legacy`, and `batch_mint`
- New owner appended on every `transfer_agent` call

## Acceptance Criteria Coverage

- ✅ Previous owner recorded on transfer
- ✅ Chain traceable back to original minter (first entry)
- ✅ All ownership changes logged with timestamps (`acquired_at`)
- ✅ `get_ownership_history` supports querying complete history for any asset
- ✅ Append-only storage prevents tampering with history records
- ✅ Tests verifying chain integrity across multiple transfers

## Tests

8 new tests in `contracts/agent-nft/src/test.rs` covering: mint via all three paths, multi-transfer chain ordering, traceability to original minter, independent history per agent, and error cases (zero id, nonexistent agent).

Closes #238