### PR TITLE
Add dynamic fee distribution contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fee-distribution"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "contracts/compliance-integration",
     "contracts/execution-hub",
+    "contracts/fee-distribution",
     "contracts/membership-subscription",
     "contracts/marketplace",
     "contracts/multisig-wallet",

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Replace names below with the repository's actual contract filenames and modules.
   - Supports cliffs, batch beneficiary schedules, beneficiary claims, admin schedule edits, revocation, and early withdrawal penalties.
   - Emits lifecycle events for schedule creation, claims, batch funding, modifications, revocations, and early exits.
 
+- FeeDistribution (fee-distribution)
+  - Collects protocol fees from transactions and holds them in custody for distribution.
+  - Supports configurable recipient categories (treasury, stakers, developers, etc.) with percentage-based shares, batched distribution and claims, fee exemptions, and distribution history for analytics.
+  - Fee rate is governance-adjustable within a bounded step per call, with a separate emergency override and a hard-coded ceiling.
+
 - MembershipSubscription (membership-subscription)
   - Tiered membership contract for recurring Soroban token subscriptions.
   - Supports trials, pull-based renewals, cancellation refunds, pause/resume, tier changes with proration, referral rewards, benefit entitlement checks, and subscription analytics.

--- a/contracts/fee-distribution/Cargo.toml
+++ b/contracts/fee-distribution/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fee-distribution"
+version = "0.1.0"
+description = "Soroban dynamic fee distribution contract with configurable recipient categories, batched claims, and exemptions"
+authors = ["StellAIverse Team"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/fee-distribution/src/lib.rs
+++ b/contracts/fee-distribution/src/lib.rs
@@ -1,0 +1,850 @@
+#![no_std]
+#![allow(clippy::too_many_arguments)]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token::TokenClient, Address, Env, Symbol,
+    Vec,
+};
+
+const BPS_DENOMINATOR: i128 = 10_000;
+/// Absolute ceiling on the fee rate, enforced even for emergency adjustments.
+const HARD_CAP_FEE_RATE_BPS: u32 = 2_000;
+/// Maximum change per `set_fee_rate` call; larger jumps require `emergency_set_fee_rate`.
+const MAX_FEE_RATE_STEP_BPS: u32 = 500;
+const MAX_CATEGORIES: u32 = 20;
+const MAX_BATCH_SIZE: u32 = 50;
+const MAX_HISTORY_LIMIT: u32 = 100;
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Token,
+    Paused,
+    FeeRateBps,
+    MaxFeeRateBps,
+    TotalCollected,
+    TotalAllocated,
+    TotalSharesBps,
+    CategoryIds,
+    Category(Symbol),
+    Exempt(Address),
+    DistributionCounter,
+    Distribution(u64),
+    ReentrancyLock,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct RecipientCategory {
+    pub category_id: Symbol,
+    pub recipient: Address,
+    pub share_bps: u32,
+    pub total_allocated: i128,
+    pub total_claimed: i128,
+    pub active: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CategoryAllocation {
+    pub category_id: Symbol,
+    pub amount: i128,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct DistributionRecord {
+    pub distribution_id: u64,
+    pub total_amount: i128,
+    pub category_count: u32,
+    pub timestamp: u64,
+    pub allocations: Vec<CategoryAllocation>,
+}
+
+#[contract]
+pub struct FeeDistribution;
+
+#[contractimpl]
+impl FeeDistribution {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        token: Address,
+        fee_rate_bps: u32,
+        max_fee_rate_bps: u32,
+    ) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        Self::validate_max_rate(max_fee_rate_bps);
+        if fee_rate_bps > max_fee_rate_bps {
+            panic!("Fee rate exceeds max fee rate");
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Token, &token);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeRateBps, &fee_rate_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxFeeRateBps, &max_fee_rate_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalCollected, &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalAllocated, &0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSharesBps, &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::CategoryIds, &Vec::<Symbol>::new(&env));
+        env.storage()
+            .instance()
+            .set(&DataKey::DistributionCounter, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyLock, &false);
+
+        env.events()
+            .publish((symbol_short!("fee_init"),), (admin, token, fee_rate_bps));
+    }
+
+    // ----- Admin controls -----
+
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+        if Self::paused(&env) {
+            panic!("Already paused");
+        }
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish((symbol_short!("fee_pause"),), admin);
+    }
+
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+        if !Self::paused(&env) {
+            panic!("Not paused");
+        }
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish((symbol_short!("fee_resm"),), admin);
+    }
+
+    pub fn set_fee_rate(env: Env, admin: Address, new_rate_bps: u32) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let max_rate = Self::max_fee_rate(&env);
+        if new_rate_bps > max_rate {
+            panic!("Fee rate exceeds max fee rate");
+        }
+        let current = Self::fee_rate(&env);
+        let delta = new_rate_bps.abs_diff(current);
+        if delta > MAX_FEE_RATE_STEP_BPS {
+            panic!("Rate change exceeds max step; use emergency_set_fee_rate");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeRateBps, &new_rate_bps);
+        env.events()
+            .publish((symbol_short!("fee_rate"),), (admin, new_rate_bps));
+    }
+
+    pub fn emergency_set_fee_rate(env: Env, admin: Address, new_rate_bps: u32) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let max_rate = Self::max_fee_rate(&env);
+        if new_rate_bps > max_rate {
+            panic!("Fee rate exceeds max fee rate");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeRateBps, &new_rate_bps);
+        env.events()
+            .publish((symbol_short!("fee_emg"),), (admin, new_rate_bps));
+    }
+
+    pub fn set_max_fee_rate(env: Env, admin: Address, new_max_bps: u32) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+        Self::validate_max_rate(new_max_bps);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxFeeRateBps, &new_max_bps);
+        if Self::fee_rate(&env) > new_max_bps {
+            env.storage()
+                .instance()
+                .set(&DataKey::FeeRateBps, &new_max_bps);
+        }
+        env.events()
+            .publish((symbol_short!("fee_maxr"),), (admin, new_max_bps));
+    }
+
+    pub fn add_category(
+        env: Env,
+        admin: Address,
+        category_id: Symbol,
+        recipient: Address,
+        share_bps: u32,
+    ) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::Category(category_id.clone()))
+        {
+            panic!("Category already exists");
+        }
+        Self::validate_share(share_bps);
+
+        let mut category_ids = Self::category_ids(&env);
+        if category_ids.len() >= MAX_CATEGORIES {
+            panic!("Maximum categories reached");
+        }
+
+        let total_shares = Self::total_shares_bps(&env);
+        let new_total = total_shares
+            .checked_add(share_bps)
+            .expect("Share total overflow");
+        if new_total > BPS_DENOMINATOR as u32 {
+            panic!("Total shares exceed 100%");
+        }
+
+        let category = RecipientCategory {
+            category_id: category_id.clone(),
+            recipient: recipient.clone(),
+            share_bps,
+            total_allocated: 0,
+            total_claimed: 0,
+            active: true,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::Category(category_id.clone()), &category);
+
+        category_ids.push_back(category_id.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::CategoryIds, &category_ids);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSharesBps, &new_total);
+
+        env.events().publish(
+            (symbol_short!("fee_cat"),),
+            (category_id, recipient, share_bps),
+        );
+    }
+
+    pub fn update_category(
+        env: Env,
+        admin: Address,
+        category_id: Symbol,
+        new_recipient: Option<Address>,
+        new_share_bps: Option<u32>,
+    ) -> RecipientCategory {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let mut category = Self::load_category(&env, &category_id);
+        if !category.active {
+            panic!("Category is not active");
+        }
+
+        if let Some(share_bps) = new_share_bps {
+            Self::validate_share(share_bps);
+            let total_shares = Self::total_shares_bps(&env);
+            let remaining = total_shares
+                .checked_sub(category.share_bps)
+                .expect("Share total underflow");
+            let new_total = remaining
+                .checked_add(share_bps)
+                .expect("Share total overflow");
+            if new_total > BPS_DENOMINATOR as u32 {
+                panic!("Total shares exceed 100%");
+            }
+            env.storage()
+                .instance()
+                .set(&DataKey::TotalSharesBps, &new_total);
+            category.share_bps = share_bps;
+        }
+
+        if let Some(recipient) = new_recipient {
+            category.recipient = recipient;
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Category(category_id.clone()), &category);
+        env.events()
+            .publish((symbol_short!("fee_catu"),), (category_id, admin));
+        category
+    }
+
+    pub fn remove_category(env: Env, admin: Address, category_id: Symbol) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let mut category = Self::load_category(&env, &category_id);
+        if !category.active {
+            panic!("Category already inactive");
+        }
+
+        let total_shares = Self::total_shares_bps(&env);
+        let new_total = total_shares
+            .checked_sub(category.share_bps)
+            .expect("Share total underflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSharesBps, &new_total);
+
+        category.active = false;
+        category.share_bps = 0;
+        env.storage()
+            .instance()
+            .set(&DataKey::Category(category_id.clone()), &category);
+
+        env.events()
+            .publish((symbol_short!("fee_catr"),), (category_id, admin));
+    }
+
+    pub fn reactivate_category(env: Env, admin: Address, category_id: Symbol, share_bps: u32) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let mut category = Self::load_category(&env, &category_id);
+        if category.active {
+            panic!("Category already active");
+        }
+        Self::validate_share(share_bps);
+
+        let total_shares = Self::total_shares_bps(&env);
+        let new_total = total_shares
+            .checked_add(share_bps)
+            .expect("Share total overflow");
+        if new_total > BPS_DENOMINATOR as u32 {
+            panic!("Total shares exceed 100%");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSharesBps, &new_total);
+
+        category.active = true;
+        category.share_bps = share_bps;
+        env.storage()
+            .instance()
+            .set(&DataKey::Category(category_id.clone()), &category);
+
+        env.events()
+            .publish((symbol_short!("fee_catv"),), (category_id, admin));
+    }
+
+    pub fn set_exempt(env: Env, admin: Address, account: Address, exempt: bool) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Exempt(account.clone()), &exempt);
+        env.events()
+            .publish((symbol_short!("fee_exm"),), (account, exempt));
+    }
+
+    // ----- Fee collection -----
+
+    /// Computes the fee owed on `amount` at the current fee rate.
+    ///
+    /// Example: with a fee rate of 250 bps (2.5%), `calculate_fee(10_000)` returns `250`.
+    pub fn calculate_fee(env: Env, amount: i128) -> i128 {
+        if amount <= 0 {
+            panic!("Amount must be positive");
+        }
+        let rate = Self::fee_rate(&env);
+        amount
+            .checked_mul(rate as i128)
+            .expect("Fee multiplication overflow")
+            / BPS_DENOMINATOR
+    }
+
+    pub fn collect_fee(env: Env, payer: Address, gross_amount: i128) -> i128 {
+        payer.require_auth();
+        if Self::paused(&env) {
+            panic!("Fee collection is paused");
+        }
+        if gross_amount <= 0 {
+            panic!("Amount must be positive");
+        }
+
+        if Self::is_exempt(env.clone(), payer.clone()) {
+            env.events()
+                .publish((symbol_short!("fee_col"),), (payer, gross_amount, 0i128));
+            return 0;
+        }
+
+        let fee = Self::calculate_fee(env.clone(), gross_amount);
+        if fee <= 0 {
+            return 0;
+        }
+
+        let token = Self::token(&env);
+        let contract_address = env.current_contract_address();
+        Self::transfer_token(&env, &token, &payer, &contract_address, fee);
+
+        let total_collected = Self::total_collected(&env)
+            .checked_add(fee)
+            .expect("Total collected overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalCollected, &total_collected);
+
+        env.events()
+            .publish((symbol_short!("fee_col"),), (payer, gross_amount, fee));
+        fee
+    }
+
+    // ----- Distribution -----
+
+    pub fn distribute(env: Env) -> DistributionRecord {
+        let total_shares = Self::total_shares_bps(&env);
+        if total_shares != BPS_DENOMINATOR as u32 {
+            panic!("Recipient shares are not fully configured");
+        }
+
+        let total_collected = Self::total_collected(&env);
+        let total_allocated = Self::total_allocated(&env);
+        let pending = total_collected
+            .checked_sub(total_allocated)
+            .expect("Pending underflow");
+        if pending <= 0 {
+            panic!("No pending fees to distribute");
+        }
+
+        let category_ids = Self::category_ids(&env);
+        let mut allocations = Vec::new(&env);
+        let mut allocated_sum: i128 = 0;
+        let mut active_count: u32 = 0;
+        for idx in 0..category_ids.len() {
+            let category_id = category_ids.get_unchecked(idx);
+            let category = Self::load_category(&env, &category_id);
+            if category.active && category.share_bps > 0 {
+                active_count += 1;
+            }
+        }
+        if active_count == 0 {
+            panic!("No active recipient categories");
+        }
+
+        let mut processed: u32 = 0;
+        for idx in 0..category_ids.len() {
+            let category_id = category_ids.get_unchecked(idx);
+            let mut category = Self::load_category(&env, &category_id);
+            if !category.active || category.share_bps == 0 {
+                continue;
+            }
+            processed += 1;
+
+            let mut amount = pending
+                .checked_mul(category.share_bps as i128)
+                .expect("Allocation multiplication overflow")
+                / BPS_DENOMINATOR;
+
+            if processed == active_count {
+                // Assign rounding remainder to the last active category so the
+                // sum of allocations always equals `pending` exactly.
+                let remainder = pending
+                    .checked_sub(allocated_sum)
+                    .expect("Remainder underflow")
+                    .checked_sub(amount)
+                    .expect("Remainder underflow");
+                amount = amount.checked_add(remainder).expect("Remainder overflow");
+            }
+
+            category.total_allocated = category
+                .total_allocated
+                .checked_add(amount)
+                .expect("Category allocation overflow");
+            env.storage()
+                .instance()
+                .set(&DataKey::Category(category_id.clone()), &category);
+
+            allocated_sum = allocated_sum
+                .checked_add(amount)
+                .expect("Allocated sum overflow");
+            allocations.push_back(CategoryAllocation {
+                category_id,
+                amount,
+            });
+        }
+
+        let new_total_allocated = total_allocated
+            .checked_add(pending)
+            .expect("Total allocated overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalAllocated, &new_total_allocated);
+
+        let distribution_id = Self::next_distribution_id(&env);
+        let record = DistributionRecord {
+            distribution_id,
+            total_amount: pending,
+            category_count: active_count,
+            timestamp: env.ledger().timestamp(),
+            allocations,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::Distribution(distribution_id), &record);
+
+        env.events().publish(
+            (symbol_short!("fee_dist"),),
+            (distribution_id, pending, active_count),
+        );
+
+        record
+    }
+
+    pub fn claim(env: Env, category_id: Symbol, recipient: Address) -> i128 {
+        recipient.require_auth();
+        let paid = Self::claim_one(&env, &category_id, &recipient, true);
+        if paid <= 0 {
+            panic!("Nothing to claim");
+        }
+        paid
+    }
+
+    pub fn claim_batch(env: Env, category_ids: Vec<Symbol>, recipient: Address) -> i128 {
+        recipient.require_auth();
+        if category_ids.is_empty() {
+            panic!("No categories provided");
+        }
+        if category_ids.len() > MAX_BATCH_SIZE {
+            panic!("Batch exceeds maximum size");
+        }
+
+        let mut total_paid: i128 = 0;
+        for idx in 0..category_ids.len() {
+            let category_id = category_ids.get_unchecked(idx);
+            let paid = Self::claim_one(&env, &category_id, &recipient, false);
+            total_paid = total_paid.checked_add(paid).expect("Claim total overflow");
+        }
+        if total_paid <= 0 {
+            panic!("Nothing to claim");
+        }
+
+        env.events().publish(
+            (symbol_short!("fee_bclm"),),
+            (recipient, total_paid, category_ids.len()),
+        );
+        total_paid
+    }
+
+    // ----- Views -----
+
+    pub fn get_admin(env: Env) -> Address {
+        Self::admin(&env)
+    }
+
+    pub fn get_token(env: Env) -> Address {
+        Self::token(&env)
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        Self::paused(&env)
+    }
+
+    pub fn get_fee_rate(env: Env) -> u32 {
+        Self::fee_rate(&env)
+    }
+
+    pub fn get_max_fee_rate(env: Env) -> u32 {
+        Self::max_fee_rate(&env)
+    }
+
+    pub fn is_exempt(env: Env, account: Address) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Exempt(account))
+            .unwrap_or(false)
+    }
+
+    pub fn get_category(env: Env, category_id: Symbol) -> RecipientCategory {
+        Self::load_category(&env, &category_id)
+    }
+
+    pub fn get_category_ids(env: Env) -> Vec<Symbol> {
+        Self::category_ids(&env)
+    }
+
+    pub fn get_claimable(env: Env, category_id: Symbol) -> i128 {
+        let category = Self::load_category(&env, &category_id);
+        category
+            .total_allocated
+            .checked_sub(category.total_claimed)
+            .expect("Claimable underflow")
+    }
+
+    pub fn get_total_shares_bps(env: Env) -> u32 {
+        Self::total_shares_bps(&env)
+    }
+
+    pub fn get_total_collected(env: Env) -> i128 {
+        Self::total_collected(&env)
+    }
+
+    pub fn get_total_allocated(env: Env) -> i128 {
+        Self::total_allocated(&env)
+    }
+
+    pub fn get_total_claimed(env: Env) -> i128 {
+        let category_ids = Self::category_ids(&env);
+        let mut total: i128 = 0;
+        for idx in 0..category_ids.len() {
+            let category_id = category_ids.get_unchecked(idx);
+            let category = Self::load_category(&env, &category_id);
+            total = total
+                .checked_add(category.total_claimed)
+                .expect("Total claimed overflow");
+        }
+        total
+    }
+
+    pub fn get_pending_distribution(env: Env) -> i128 {
+        Self::total_collected(&env)
+            .checked_sub(Self::total_allocated(&env))
+            .expect("Pending underflow")
+    }
+
+    pub fn get_distribution_counter(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DistributionCounter)
+            .unwrap_or(0u64)
+    }
+
+    pub fn get_distribution(env: Env, distribution_id: u64) -> DistributionRecord {
+        env.storage()
+            .instance()
+            .get(&DataKey::Distribution(distribution_id))
+            .expect("Distribution not found")
+    }
+
+    /// Returns up to `limit` distribution records, most recent first, starting
+    /// `offset` records back from the latest distribution.
+    pub fn get_distribution_history(env: Env, offset: u32, limit: u32) -> Vec<DistributionRecord> {
+        let bounded_limit = if limit > MAX_HISTORY_LIMIT {
+            MAX_HISTORY_LIMIT
+        } else {
+            limit
+        };
+        let counter = Self::get_distribution_counter(env.clone());
+        let mut records = Vec::new(&env);
+        if bounded_limit == 0 || counter <= offset as u64 {
+            return records;
+        }
+
+        let start = counter - offset as u64;
+        let mut fetched: u32 = 0;
+        let mut id = start;
+        while id >= 1 && fetched < bounded_limit {
+            records.push_back(Self::get_distribution(env.clone(), id));
+            fetched += 1;
+            id -= 1;
+        }
+        records
+    }
+
+    // ----- Internal helpers -----
+
+    fn claim_one(
+        env: &Env,
+        category_id: &Symbol,
+        recipient: &Address,
+        require_positive: bool,
+    ) -> i128 {
+        let mut category = Self::load_category(env, category_id);
+        if category.recipient != *recipient {
+            if require_positive {
+                panic!("Only recipient can claim");
+            }
+            return 0;
+        }
+
+        let claimable = category
+            .total_allocated
+            .checked_sub(category.total_claimed)
+            .expect("Claimable underflow");
+        if claimable <= 0 {
+            if require_positive {
+                panic!("Nothing to claim");
+            }
+            return 0;
+        }
+
+        category.total_claimed = category
+            .total_claimed
+            .checked_add(claimable)
+            .expect("Claimed overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::Category(category_id.clone()), &category);
+
+        let token = Self::token(env);
+        let contract_address = env.current_contract_address();
+        Self::transfer_token(env, &token, &contract_address, recipient, claimable);
+
+        env.events().publish(
+            (symbol_short!("fee_clm"),),
+            (category_id.clone(), recipient.clone(), claimable),
+        );
+
+        claimable
+    }
+
+    fn next_distribution_id(env: &Env) -> u64 {
+        let current = env
+            .storage()
+            .instance()
+            .get(&DataKey::DistributionCounter)
+            .unwrap_or(0u64);
+        let next = current.checked_add(1).expect("Distribution ID overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::DistributionCounter, &next);
+        next
+    }
+
+    fn load_category(env: &Env, category_id: &Symbol) -> RecipientCategory {
+        env.storage()
+            .instance()
+            .get(&DataKey::Category(category_id.clone()))
+            .expect("Category not found")
+    }
+
+    fn category_ids(env: &Env) -> Vec<Symbol> {
+        env.storage()
+            .instance()
+            .get(&DataKey::CategoryIds)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    fn total_shares_bps(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalSharesBps)
+            .unwrap_or(0u32)
+    }
+
+    fn total_collected(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalCollected)
+            .unwrap_or(0i128)
+    }
+
+    fn total_allocated(env: &Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalAllocated)
+            .unwrap_or(0i128)
+    }
+
+    fn fee_rate(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::FeeRateBps)
+            .expect("Contract not initialized")
+    }
+
+    fn max_fee_rate(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxFeeRateBps)
+            .expect("Contract not initialized")
+    }
+
+    fn paused(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    fn token(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("Contract not initialized")
+    }
+
+    fn admin(env: &Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized")
+    }
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        let admin = Self::admin(env);
+        if caller != &admin {
+            panic!("Unauthorized: caller is not admin");
+        }
+    }
+
+    fn validate_share(share_bps: u32) {
+        if share_bps == 0 || share_bps > BPS_DENOMINATOR as u32 {
+            panic!("Share must be between 1 and 10000 bps");
+        }
+    }
+
+    fn validate_max_rate(max_fee_rate_bps: u32) {
+        if max_fee_rate_bps == 0 || max_fee_rate_bps > HARD_CAP_FEE_RATE_BPS {
+            panic!("Max fee rate exceeds hard cap");
+        }
+    }
+
+    fn transfer_token(env: &Env, token: &Address, from: &Address, to: &Address, amount: i128) {
+        Self::enter_non_reentrant(env);
+        if amount <= 0 {
+            panic!("Transfer amount must be positive");
+        }
+        let token_client = TokenClient::new(env, token);
+        token_client.transfer(from, to, &amount);
+        Self::exit_non_reentrant(env);
+    }
+
+    fn enter_non_reentrant(env: &Env) {
+        let locked = env
+            .storage()
+            .instance()
+            .get(&DataKey::ReentrancyLock)
+            .unwrap_or(false);
+        if locked {
+            panic!("Reentrant call blocked");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyLock, &true);
+    }
+
+    fn exit_non_reentrant(env: &Env) {
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyLock, &false);
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/fee-distribution/src/test.rs
+++ b/contracts/fee-distribution/src/test.rs
@@ -1,0 +1,346 @@
+use super::*;
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::{Address as _, Ledger as _},
+    Address, Env, Symbol, Vec,
+};
+
+#[contract]
+pub struct MockToken;
+
+#[derive(Clone)]
+#[contracttype]
+pub enum MockTokenKey {
+    Balance(Address),
+}
+
+#[contractimpl]
+impl MockToken {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        if amount <= 0 {
+            panic!("Mint amount must be positive");
+        }
+        let key = MockTokenKey::Balance(to);
+        let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&key, &(current.checked_add(amount).unwrap()));
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get(&MockTokenKey::Balance(id))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        if amount <= 0 {
+            panic!("Transfer amount must be positive");
+        }
+
+        let from_key = MockTokenKey::Balance(from);
+        let from_balance: i128 = env.storage().instance().get(&from_key).unwrap_or(0);
+        if from_balance < amount {
+            panic!("Insufficient balance");
+        }
+        env.storage()
+            .instance()
+            .set(&from_key, &(from_balance - amount));
+
+        let to_key = MockTokenKey::Balance(to);
+        let to_balance: i128 = env.storage().instance().get(&to_key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&to_key, &(to_balance.checked_add(amount).unwrap()));
+    }
+}
+
+fn setup() -> (
+    Env,
+    FeeDistributionClient<'static>,
+    MockTokenClient<'static>,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+
+    let admin = Address::generate(&env);
+    let payer = Address::generate(&env);
+
+    let fee_id = env.register(FeeDistribution, ());
+    let fee = FeeDistributionClient::new(&env, &fee_id);
+
+    let token_id = env.register(MockToken, ());
+    let token = MockTokenClient::new(&env, &token_id);
+    token.mint(&payer, &1_000_000);
+
+    fee.initialize(&admin, &token_id, &500u32, &2_000u32);
+
+    (env, fee, token, admin, payer)
+}
+
+fn add_default_categories(
+    env: &Env,
+    fee: &FeeDistributionClient<'_>,
+    admin: &Address,
+) -> (Symbol, Symbol, Address, Address) {
+    let treasury_id = Symbol::new(env, "treasury");
+    let stakers_id = Symbol::new(env, "stakers");
+    let treasury = Address::generate(env);
+    let stakers = Address::generate(env);
+
+    fee.add_category(admin, &treasury_id, &treasury, &6_000u32);
+    fee.add_category(admin, &stakers_id, &stakers, &4_000u32);
+
+    (treasury_id, stakers_id, treasury, stakers)
+}
+
+#[test]
+fn calculate_fee_applies_bps_rate() {
+    let (_env, fee, _token, _admin, _payer) = setup();
+    assert_eq!(fee.calculate_fee(&10_000), 500);
+    assert_eq!(fee.calculate_fee(&1), 0);
+    assert_eq!(fee.calculate_fee(&1_000_000), 50_000);
+}
+
+#[test]
+fn collect_fee_pulls_tokens_and_tracks_totals() {
+    let (_env, fee, token, _admin, payer) = setup();
+
+    let collected = fee.collect_fee(&payer, &10_000);
+    assert_eq!(collected, 500);
+    assert_eq!(token.balance(&payer), 999_500);
+    assert_eq!(token.balance(&fee.address), 500);
+    assert_eq!(fee.get_total_collected(), 500);
+    assert_eq!(fee.get_pending_distribution(), 500);
+}
+
+#[test]
+fn exempt_accounts_are_not_charged() {
+    let (_env, fee, token, admin, payer) = setup();
+
+    fee.set_exempt(&admin, &payer, &true);
+    assert!(fee.is_exempt(&payer));
+
+    let collected = fee.collect_fee(&payer, &10_000);
+    assert_eq!(collected, 0);
+    assert_eq!(token.balance(&payer), 1_000_000);
+    assert_eq!(fee.get_total_collected(), 0);
+}
+
+#[test]
+fn distribute_splits_fees_by_share_and_handles_rounding_remainder() {
+    let (env, fee, _token, admin, payer) = setup();
+    let (treasury_id, stakers_id, _treasury, _stakers) = add_default_categories(&env, &fee, &admin);
+
+    // 200_020 at 5% bps rate yields a fee whose 60/40 split doesn't divide evenly.
+    fee.collect_fee(&payer, &200_020);
+    let pending = fee.get_pending_distribution();
+    assert_eq!(pending, 10_001);
+
+    let record = fee.distribute();
+    assert_eq!(record.total_amount, 10_001);
+    assert_eq!(record.category_count, 2);
+
+    let treasury_share = fee.get_claimable(&treasury_id);
+    let stakers_share = fee.get_claimable(&stakers_id);
+    // 60% of 10_001 = 6_000 (floor); remainder goes to the last active category.
+    assert_eq!(treasury_share, 6_000);
+    assert_eq!(stakers_share, 4_001);
+    assert_eq!(treasury_share + stakers_share, pending);
+}
+
+#[test]
+#[should_panic(expected = "Recipient shares are not fully configured")]
+fn distribute_requires_full_share_allocation() {
+    let (env, fee, _token, admin, payer) = setup();
+    let treasury_id = Symbol::new(&env, "treasury");
+    let treasury = Address::generate(&env);
+    fee.add_category(&admin, &treasury_id, &treasury, &6_000u32);
+
+    fee.collect_fee(&payer, &10_000);
+    fee.distribute();
+}
+
+#[test]
+fn recipients_can_claim_allocated_fees() {
+    let (env, fee, token, admin, payer) = setup();
+    let (treasury_id, stakers_id, treasury, stakers) = add_default_categories(&env, &fee, &admin);
+
+    fee.collect_fee(&payer, &200_000);
+    fee.distribute();
+
+    let claimed = fee.claim(&treasury_id, &treasury);
+    assert_eq!(claimed, 6_000);
+    assert_eq!(token.balance(&treasury), 6_000);
+    assert_eq!(fee.get_claimable(&treasury_id), 0);
+
+    let claimed_stakers = fee.claim(&stakers_id, &stakers);
+    assert_eq!(claimed_stakers, 4_000);
+    assert_eq!(token.balance(&stakers), 4_000);
+    assert_eq!(fee.get_total_claimed(), 10_000);
+}
+
+#[test]
+fn claim_batch_pays_multiple_categories_in_one_call() {
+    let (env, fee, token, admin, payer) = setup();
+    let recipient = Address::generate(&env);
+
+    let cat_a = Symbol::new(&env, "cat_a");
+    let cat_b = Symbol::new(&env, "cat_b");
+    fee.add_category(&admin, &cat_a, &recipient, &5_000u32);
+    fee.add_category(&admin, &cat_b, &recipient, &5_000u32);
+
+    fee.collect_fee(&payer, &200_000);
+    fee.distribute();
+
+    let ids = Vec::from_array(&env, [cat_a, cat_b]);
+    let total = fee.claim_batch(&ids, &recipient);
+    assert_eq!(total, 10_000);
+    assert_eq!(token.balance(&recipient), 10_000);
+}
+
+#[test]
+#[should_panic(expected = "Only recipient can claim")]
+fn claim_rejects_non_recipient_caller() {
+    let (env, fee, _token, admin, payer) = setup();
+    let (treasury_id, _stakers_id, _treasury, _stakers) =
+        add_default_categories(&env, &fee, &admin);
+    let stranger = Address::generate(&env);
+
+    fee.collect_fee(&payer, &200_000);
+    fee.distribute();
+
+    fee.claim(&treasury_id, &stranger);
+}
+
+#[test]
+fn set_fee_rate_allows_small_steps_and_rejects_large_jumps() {
+    let (_env, fee, _token, admin, _payer) = setup();
+    fee.set_fee_rate(&admin, &900u32);
+    assert_eq!(fee.get_fee_rate(), 900);
+}
+
+#[test]
+#[should_panic(expected = "Rate change exceeds max step")]
+fn set_fee_rate_rejects_jump_beyond_step_limit() {
+    let (_env, fee, _token, admin, _payer) = setup();
+    fee.set_fee_rate(&admin, &1_500u32);
+}
+
+#[test]
+fn emergency_set_fee_rate_bypasses_step_limit_but_respects_max() {
+    let (_env, fee, _token, admin, _payer) = setup();
+    fee.emergency_set_fee_rate(&admin, &2_000u32);
+    assert_eq!(fee.get_fee_rate(), 2_000);
+}
+
+#[test]
+#[should_panic(expected = "Fee rate exceeds max fee rate")]
+fn emergency_set_fee_rate_still_respects_configured_max() {
+    let (_env, fee, _token, admin, _payer) = setup();
+    fee.emergency_set_fee_rate(&admin, &2_001u32);
+}
+
+#[test]
+#[should_panic(expected = "Max fee rate exceeds hard cap")]
+fn set_max_fee_rate_rejects_beyond_hard_cap() {
+    let (_env, fee, _token, admin, _payer) = setup();
+    fee.set_max_fee_rate(&admin, &2_001u32);
+}
+
+#[test]
+fn pause_blocks_collection_but_not_claims() {
+    let (env, fee, token, admin, payer) = setup();
+    let (treasury_id, _stakers_id, treasury, _stakers) = add_default_categories(&env, &fee, &admin);
+
+    fee.collect_fee(&payer, &200_000);
+    fee.distribute();
+
+    fee.pause(&admin);
+    assert!(fee.is_paused());
+
+    let claimed = fee.claim(&treasury_id, &treasury);
+    assert_eq!(claimed, 6_000);
+    assert_eq!(token.balance(&treasury), 6_000);
+
+    fee.unpause(&admin);
+    assert!(!fee.is_paused());
+    let _ = env;
+}
+
+#[test]
+#[should_panic(expected = "Fee collection is paused")]
+fn collect_fee_rejected_while_paused() {
+    let (_env, fee, _token, admin, payer) = setup();
+    fee.pause(&admin);
+    fee.collect_fee(&payer, &10_000);
+}
+
+#[test]
+fn remove_and_reactivate_category_updates_shares() {
+    let (env, fee, _token, admin, _payer) = setup();
+    let (treasury_id, _stakers_id, _treasury, _stakers) =
+        add_default_categories(&env, &fee, &admin);
+
+    assert_eq!(fee.get_total_shares_bps(), 10_000);
+    fee.remove_category(&admin, &treasury_id);
+    assert_eq!(fee.get_total_shares_bps(), 4_000);
+    assert!(!fee.get_category(&treasury_id).active);
+
+    fee.reactivate_category(&admin, &treasury_id, &3_000u32);
+    assert_eq!(fee.get_total_shares_bps(), 7_000);
+    assert!(fee.get_category(&treasury_id).active);
+    let _ = env;
+}
+
+#[test]
+#[should_panic(expected = "Total shares exceed 100%")]
+fn add_category_rejects_shares_over_100_percent() {
+    let (env, fee, _token, admin, _payer) = setup();
+    add_default_categories(&env, &fee, &admin);
+
+    let extra_id = Symbol::new(&env, "extra");
+    let extra = Address::generate(&env);
+    fee.add_category(&admin, &extra_id, &extra, &1u32);
+}
+
+#[test]
+fn distribution_history_is_queryable_for_analytics() {
+    let (env, fee, _token, admin, payer) = setup();
+    add_default_categories(&env, &fee, &admin);
+
+    fee.collect_fee(&payer, &200_000);
+    let first = fee.distribute();
+
+    fee.collect_fee(&payer, &200_000);
+    let second = fee.distribute();
+
+    assert_eq!(fee.get_distribution_counter(), 2);
+
+    let history = fee.get_distribution_history(&0u32, &10u32);
+    assert_eq!(history.len(), 2);
+    assert_eq!(
+        history.get_unchecked(0).distribution_id,
+        second.distribution_id
+    );
+    assert_eq!(
+        history.get_unchecked(1).distribution_id,
+        first.distribution_id
+    );
+    let _ = env;
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized: caller is not admin")]
+fn non_admin_cannot_add_category() {
+    let (env, fee, _token, _admin, _payer) = setup();
+    let stranger = Address::generate(&env);
+    let treasury_id = Symbol::new(&env, "treasury");
+    let treasury = Address::generate(&env);
+    fee.add_category(&stranger, &treasury_id, &treasury, &6_000u32);
+}


### PR DESCRIPTION
Adds a Soroban fee-distribution contract that collects protocol fees and splits them across configurable recipient categories (treasury, stakers, developers, etc.) by basis-point share.

- Governance-adjustable fee rate with a bounded per-call step, plus a separate emergency override and a hard-coded ceiling
- Percentage-based recipient categories with admin add/update/remove/reactivate
- Fee exemptions for privileged accounts
- Batched distribution across categories and batched claims across categories for a single recipient
- Distribution history with per-category allocation breakdown for analytics
- Pause/unpause halts new fee collection while leaving existing claims available
- 19 unit tests covering collection, exemptions, rate limits, pausing, category management, distribution rounding, and claims

Closes #271