### PR TITLE
feat(amm): Add constant-product AMM module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "amm"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "stellai_lib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "contracts/amm",
     "contracts/compliance-integration",
     "contracts/execution-hub",
     "contracts/fee-distribution",

--- a/contracts/amm/Cargo.toml
+++ b/contracts/amm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "amm"
+version = "0.1.0"
+description = "Constant product AMM for decentralized token swaps and liquidity provision"
+authors = ["StellAIverse Team"]
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+stellai_lib = { path = "../../lib" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/amm/src/lib.rs
+++ b/contracts/amm/src/lib.rs
@@ -1,0 +1,1106 @@
+#![no_std]
+
+mod math;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, token::TokenClient, Address, Env, String, Symbol, Vec,
+};
+use stellai_lib::{errors::ContractError, rbac, ADMIN_KEY};
+
+use math::{ceil_div, floor_div, get_amount_in, get_amount_out, isqrt};
+use storage::*;
+use types::*;
+
+const BPS_DENOMINATOR: i128 = 10_000;
+const MAX_FEE_BPS: u32 = 1_000;
+const MAX_PROTOCOL_FEE_SHARE_BPS: u32 = 5_000;
+const DEPOSIT_RATIO_TOLERANCE_BPS: i128 = 500;
+const PRICE_SCALE: i128 = 1_000_000;
+
+#[contract]
+pub struct Amm;
+
+#[contractimpl]
+impl Amm {
+    /// Initialize the AMM contract with an admin and optional governance fee collector.
+    pub fn initialize(env: Env, admin: Address, governance_collector: Option<Address>) {
+        if env.storage().instance().has(&Symbol::new(&env, ADMIN_KEY)) {
+            panic!("Contract already initialized");
+        }
+        admin.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, ADMIN_KEY), &admin);
+        set_pool_counter(&env, 0);
+        set_trading_paused(&env, false);
+        set_protocol_fee_share_bps(&env, 0);
+        set_reentrancy_lock(&env, false);
+
+        if let Some(collector) = governance_collector {
+            set_governance_collector(&env, &collector);
+        }
+
+        env.events().publish((symbol_short!("amm_init"),), admin);
+    }
+
+    /// Create a new liquidity pool for a token pair.
+    /// `fee_bps` is the swap fee in basis points (max 1000 = 10%).
+    pub fn create_pool(
+        env: Env,
+        admin: Address,
+        token_a: Address,
+        token_b: Address,
+        fee_bps: u32,
+    ) -> u64 {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if token_a == token_b {
+            panic!("Token addresses must differ");
+        }
+        if fee_bps > MAX_FEE_BPS {
+            panic!("Fee cannot exceed 10%");
+        }
+
+        let pool_id = get_pool_counter(&env);
+        let pool = Pool {
+            pool_id,
+            token_a,
+            token_b,
+            reserve_a: 0,
+            reserve_b: 0,
+            lp_total_supply: 0,
+            fee_bps,
+        };
+
+        set_pool(&env, &pool);
+        set_pool_counter(&env, pool_id + 1);
+
+        env.events().publish(
+            (Symbol::new(&env, "PoolCreated"),),
+            (pool_id, &pool.token_a, &pool.token_b, fee_bps),
+        );
+
+        pool_id
+    }
+
+    /// Add liquidity to a pool. Returns the number of LP tokens minted.
+    pub fn add_liquidity(
+        env: Env,
+        provider: Address,
+        pool_id: u64,
+        amount_a: i128,
+        amount_b: i128,
+    ) -> i128 {
+        provider.require_auth();
+        Self::with_reentrancy_guard(&env, || {
+            Self::add_liquidity_internal(&env, &provider, pool_id, amount_a, amount_b)
+        })
+    }
+
+    /// Remove liquidity from a pool by burning LP tokens.
+    /// Returns (amount_a, amount_b) withdrawn.
+    pub fn remove_liquidity(
+        env: Env,
+        provider: Address,
+        pool_id: u64,
+        lp_amount: i128,
+    ) -> (i128, i128) {
+        provider.require_auth();
+        Self::with_reentrancy_guard(&env, || {
+            Self::remove_liquidity_internal(&env, &provider, pool_id, lp_amount)
+        })
+    }
+
+    /// Execute a swap on a pool with slippage protection.
+    pub fn swap(
+        env: Env,
+        user: Address,
+        pool_id: u64,
+        token_in: Address,
+        amount_in: i128,
+        min_amount_out: i128,
+    ) -> i128 {
+        user.require_auth();
+        Self::check_trading_allowed(&env);
+        Self::with_reentrancy_guard(&env, || {
+            Self::swap_internal(
+                &env,
+                &user,
+                pool_id,
+                &token_in,
+                amount_in,
+                min_amount_out,
+                true,
+            )
+        })
+    }
+
+    /// Quote the output amount for a swap without executing it.
+    pub fn quote_swap(env: Env, pool_id: u64, token_in: Address, amount_in: i128) -> i128 {
+        if amount_in <= 0 {
+            panic!("Input amount must be positive");
+        }
+        let pool = get_pool(&env, pool_id);
+        let (reserve_in, reserve_out) = Self::reserves_for_token(&pool, &token_in);
+        get_amount_out(amount_in, reserve_in, reserve_out, pool.fee_bps)
+    }
+
+    /// Execute an atomic flash swap: borrow `amount_out`, then repay `token_in` in the same call.
+    pub fn flash_swap(
+        env: Env,
+        borrower: Address,
+        pool_id: u64,
+        token_out: Address,
+        amount_out: i128,
+        token_in: Address,
+        max_amount_in: i128,
+    ) -> i128 {
+        borrower.require_auth();
+        Self::check_trading_allowed(&env);
+
+        if amount_out <= 0 {
+            panic!("Flash swap amount must be positive");
+        }
+
+        Self::with_reentrancy_guard(&env, || {
+            let mut pool = get_pool(&env, pool_id);
+            Self::validate_pool_tokens(&pool, &token_in, &token_out);
+
+            let (reserve_in, reserve_out, out_is_a) =
+                Self::reserves_for_pair(&pool, &token_in, &token_out);
+
+            if reserve_out <= amount_out {
+                panic!("Insufficient pool liquidity for flash swap");
+            }
+
+            let amount_in_required =
+                get_amount_in(amount_out, reserve_in, reserve_out, pool.fee_bps);
+
+            if amount_in_required > max_amount_in {
+                panic!("Flash swap repayment exceeds max_amount_in");
+            }
+
+            let contract_addr = env.current_contract_address();
+            let token_out_client = TokenClient::new(&env, &token_out);
+            let token_in_client = TokenClient::new(&env, &token_in);
+
+            // Lend tokens to borrower, then collect repayment atomically.
+            token_out_client.transfer(&contract_addr, &borrower, &amount_out);
+            token_in_client.transfer(&borrower, &contract_addr, &amount_in_required);
+
+            let protocol_share_bps = get_protocol_fee_share_bps(&env);
+            let fee_amount = Self::calculate_swap_fee(amount_in_required, pool.fee_bps);
+            let protocol_fee = (fee_amount * protocol_share_bps as i128) / BPS_DENOMINATOR;
+
+            if protocol_fee > 0 {
+                if let Some(collector) = get_governance_collector(&env) {
+                    token_in_client.transfer(&contract_addr, &collector, &protocol_fee);
+                }
+            }
+
+            let net_in = amount_in_required - protocol_fee;
+            if out_is_a {
+                pool.reserve_a -= amount_out;
+                pool.reserve_b += net_in;
+            } else {
+                pool.reserve_b -= amount_out;
+                pool.reserve_a += net_in;
+            }
+
+            set_pool(&env, &pool);
+            invalidate_query_cache(&env, pool_id);
+
+            env.events().publish(
+                (Symbol::new(&env, "FlashSwap"),),
+                (
+                    pool_id,
+                    borrower.clone(),
+                    token_out.clone(),
+                    token_in.clone(),
+                    amount_out,
+                    amount_in_required,
+                ),
+            );
+
+            amount_in_required
+        })
+    }
+
+    /// Deposit bonus reward tokens for LP providers to claim proportionally.
+    pub fn deposit_lp_rewards(
+        env: Env,
+        admin: Address,
+        pool_id: u64,
+        token: Address,
+        amount: i128,
+    ) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if amount <= 0 {
+            panic!("Reward amount must be positive");
+        }
+
+        let pool = get_pool(&env, pool_id);
+        if token != pool.token_a && token != pool.token_b {
+            panic!("Token not in pool");
+        }
+
+        let contract_addr = env.current_contract_address();
+        TokenClient::new(&env, &token).transfer(&admin, &contract_addr, &amount);
+
+        let current = get_lp_reward_balance(&env, pool_id, &token);
+        set_lp_reward_balance(&env, pool_id, &token, current + amount);
+
+        env.events().publish(
+            (Symbol::new(&env, "LpRewardsDeposited"),),
+            (pool_id, token, amount),
+        );
+    }
+
+    /// Claim proportional LP rewards for a provider.
+    pub fn claim_lp_rewards(env: Env, provider: Address, pool_id: u64) -> (i128, i128) {
+        provider.require_auth();
+        Self::with_reentrancy_guard(&env, || {
+            let pool = get_pool(&env, pool_id);
+            let lp_balance = get_lp_balance(&env, pool_id, &provider);
+
+            if lp_balance <= 0 || pool.lp_total_supply <= 0 {
+                panic!("No LP tokens to claim rewards");
+            }
+
+            let reward_a = get_lp_reward_balance(&env, pool_id, &pool.token_a);
+            let reward_b = get_lp_reward_balance(&env, pool_id, &pool.token_b);
+
+            let share_a = floor_div(reward_a * lp_balance, pool.lp_total_supply);
+            let share_b = floor_div(reward_b * lp_balance, pool.lp_total_supply);
+
+            if share_a <= 0 && share_b <= 0 {
+                panic!("No rewards to claim");
+            }
+
+            let contract_addr = env.current_contract_address();
+            if share_a > 0 {
+                TokenClient::new(&env, &pool.token_a).transfer(&contract_addr, &provider, &share_a);
+                set_lp_reward_balance(&env, pool_id, &pool.token_a, reward_a - share_a);
+            }
+            if share_b > 0 {
+                TokenClient::new(&env, &pool.token_b).transfer(&contract_addr, &provider, &share_b);
+                set_lp_reward_balance(&env, pool_id, &pool.token_b, reward_b - share_b);
+            }
+
+            env.events().publish(
+                (Symbol::new(&env, "LpRewardsClaimed"),),
+                (pool_id, provider, share_a, share_b),
+            );
+
+            (share_a, share_b)
+        })
+    }
+
+    /// Get pool information.
+    pub fn get_pool(env: Env, pool_id: u64) -> Pool {
+        get_pool(&env, pool_id)
+    }
+
+    /// Get the current price of a token in the pool (scaled by 1_000_000).
+    pub fn get_price(env: Env, pool_id: u64, token: Address) -> i128 {
+        let pool = get_pool(&env, pool_id);
+        if pool.reserve_a <= 0 || pool.reserve_b <= 0 {
+            panic!("Pool has no liquidity");
+        }
+
+        if token == pool.token_a {
+            (pool.reserve_b * PRICE_SCALE) / pool.reserve_a
+        } else if token == pool.token_b {
+            (pool.reserve_a * PRICE_SCALE) / pool.reserve_b
+        } else {
+            panic!("Token not in pool");
+        }
+    }
+
+    /// Get the LP token balance for a provider in a pool.
+    pub fn get_lp_balance(env: Env, pool_id: u64, provider: Address) -> i128 {
+        get_lp_balance(&env, pool_id, &provider)
+    }
+
+    /// Get pending LP reward amounts for a provider.
+    pub fn get_pending_lp_rewards(env: Env, pool_id: u64, provider: Address) -> (i128, i128) {
+        let pool = get_pool(&env, pool_id);
+        let lp_balance = get_lp_balance(&env, pool_id, &provider);
+
+        if lp_balance <= 0 || pool.lp_total_supply <= 0 {
+            return (0, 0);
+        }
+
+        let reward_a = get_lp_reward_balance(&env, pool_id, &pool.token_a);
+        let reward_b = get_lp_reward_balance(&env, pool_id, &pool.token_b);
+
+        (
+            floor_div(reward_a * lp_balance, pool.lp_total_supply),
+            floor_div(reward_b * lp_balance, pool.lp_total_supply),
+        )
+    }
+
+    // ---------------- MULTI-HOP SWAP FUNCTIONALITY ----------------
+
+    /// Find the best route for a multi-hop swap.
+    pub fn find_best_route(
+        env: Env,
+        token_in: Address,
+        token_out: Address,
+        amount_in: i128,
+        max_hops: u32,
+    ) -> Route {
+        if amount_in <= 0 {
+            panic!("Input amount must be positive");
+        }
+        if token_in == token_out {
+            panic!("Tokens must be different");
+        }
+        if max_hops == 0 || max_hops > 5 {
+            panic!("Invalid max hops (1-5)");
+        }
+
+        Self::check_trading_allowed(&env);
+
+        let mut best_route: Option<Route> = None;
+        let mut best_output = 0i128;
+        let pool_counter = get_pool_counter(&env);
+
+        for pool_id in 0..pool_counter {
+            if let Some(route) =
+                Self::try_direct_route(&env, pool_id, &token_in, &token_out, amount_in)
+            {
+                if route.amount_out > best_output {
+                    best_output = route.amount_out;
+                    best_route = Some(route);
+                }
+            }
+        }
+
+        if max_hops >= 2 {
+            for pool_id_1 in 0..pool_counter {
+                for pool_id_2 in 0..pool_counter {
+                    if pool_id_1 != pool_id_2 {
+                        if let Some(route) = Self::try_two_hop_route(
+                            &env, pool_id_1, pool_id_2, &token_in, &token_out, amount_in,
+                        ) {
+                            if route.amount_out > best_output {
+                                best_output = route.amount_out;
+                                best_route = Some(route);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        best_route.unwrap_or_else(|| panic!("No valid route found"))
+    }
+
+    /// Execute a multi-hop swap atomically.
+    pub fn execute_multi_hop_swap(
+        env: Env,
+        user: Address,
+        route: Route,
+        min_amount_out: i128,
+    ) -> i128 {
+        user.require_auth();
+
+        if route.amount_in <= 0 {
+            panic!("Invalid route amount");
+        }
+        if route.amount_out < min_amount_out {
+            panic!("Route output below slippage tolerance");
+        }
+
+        Self::check_trading_allowed(&env);
+        Self::check_position_limits(&env, &user, &route.token_in, route.amount_in);
+
+        let mut current_amount = route.amount_in;
+        let mut current_token = route.token_in.clone();
+        let mut total_fees = 0u32;
+
+        for (i, hop) in route.hops.iter().enumerate() {
+            let hop_index = i as u32;
+            if hop.amount_in != current_amount {
+                panic!("Hop amount mismatch at hop {}", hop_index);
+            }
+            if hop.token_in != current_token {
+                panic!("Hop token mismatch at hop {}", hop_index);
+            }
+
+            let pool = get_pool(&env, hop.pool_id);
+            let actual_output = Self::swap_internal(
+                &env,
+                &user,
+                hop.pool_id,
+                &hop.token_in,
+                hop.amount_in,
+                hop.min_amount_out,
+                false,
+            );
+
+            current_amount = actual_output;
+            current_token = hop.token_out.clone();
+            total_fees += pool.fee_bps;
+
+            env.events().publish(
+                (Symbol::new(&env, "HopCompleted"),),
+                (
+                    hop_index,
+                    hop.pool_id,
+                    hop.token_in.clone(),
+                    hop.token_out.clone(),
+                    actual_output,
+                ),
+            );
+        }
+
+        if current_amount < min_amount_out {
+            panic!("Final output below slippage tolerance");
+        }
+        if current_token != route.token_out {
+            panic!("Final token mismatch");
+        }
+
+        Self::update_user_position(&env, &user, &route.token_in, -route.amount_in);
+        Self::update_user_position(&env, &user, &route.token_out, current_amount);
+
+        env.events().publish(
+            (Symbol::new(&env, "MultiHopSwapCompleted"),),
+            (
+                user,
+                route.token_in,
+                route.token_out,
+                route.amount_in,
+                current_amount,
+                route.hops.len(),
+                total_fees,
+            ),
+        );
+
+        current_amount
+    }
+
+    // ---------------- ADMIN & RISK MANAGEMENT ----------------
+
+    /// Pause all trading operations (admin only).
+    pub fn pause_trading(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+        set_trading_paused(&env, true);
+        env.events().publish(
+            (Symbol::new(&env, "TradingPaused"),),
+            (admin, env.ledger().timestamp()),
+        );
+    }
+
+    /// Resume all trading operations (admin only).
+    pub fn resume_trading(env: Env, admin: Address) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+        set_trading_paused(&env, false);
+        env.events().publish(
+            (Symbol::new(&env, "TradingResumed"),),
+            (admin, env.ledger().timestamp()),
+        );
+    }
+
+    /// Set a new admin (current admin only).
+    pub fn set_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        Self::assert_admin(&env, &current_admin);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, ADMIN_KEY), &new_admin);
+        env.events().publish(
+            (Symbol::new(&env, "AdminUpdated"),),
+            (current_admin, new_admin),
+        );
+    }
+
+    /// Configure governance fee collector and protocol fee share.
+    pub fn set_fee_config(
+        env: Env,
+        admin: Address,
+        governance_collector: Address,
+        protocol_fee_share_bps: u32,
+    ) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if protocol_fee_share_bps > MAX_PROTOCOL_FEE_SHARE_BPS {
+            panic!("Protocol fee share cannot exceed 50%");
+        }
+
+        set_governance_collector(&env, &governance_collector);
+        set_protocol_fee_share_bps(&env, protocol_fee_share_bps);
+
+        env.events().publish(
+            (Symbol::new(&env, "FeeConfigUpdated"),),
+            (governance_collector, protocol_fee_share_bps),
+        );
+    }
+
+    /// Set risk management parameters (admin only).
+    pub fn set_risk_parameters(env: Env, admin: Address, params: RiskParams) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        if params.max_position_per_user <= 0 {
+            panic!("Invalid max position per user");
+        }
+        if params.max_position_per_asset <= 0 {
+            panic!("Invalid max position per asset");
+        }
+        if params.concentration_threshold_bps > 10_000 {
+            panic!("Invalid concentration threshold");
+        }
+        if params.circuit_breaker_threshold_bps > 10_000 {
+            panic!("Invalid circuit breaker threshold");
+        }
+        if params.circuit_breaker_cooldown == 0 {
+            panic!("Invalid cooldown period");
+        }
+        if params.min_lp_token_threshold <= 0 {
+            panic!("Invalid LP token threshold");
+        }
+
+        set_risk_params(&env, &params);
+
+        env.events().publish(
+            (Symbol::new(&env, "RiskParamsUpdated"),),
+            (
+                params.max_position_per_user,
+                params.max_position_per_asset,
+                params.concentration_threshold_bps,
+                params.circuit_breaker_threshold_bps,
+            ),
+        );
+    }
+
+    /// Get current risk metrics for a user.
+    pub fn get_risk_metrics(env: Env, user: Address) -> (i128, i128, u32) {
+        let params = get_risk_params(&env);
+        let user_total_position = Self::get_user_total_position(&env, &user);
+        let concentration_score = Self::calculate_concentration_score(&env, &user);
+
+        (
+            user_total_position,
+            concentration_score.into(),
+            params.concentration_threshold_bps,
+        )
+    }
+
+    /// Trigger circuit breaker manually (admin only).
+    pub fn trigger_circuit_breaker(env: Env, admin: Address, reason: String) {
+        admin.require_auth();
+        Self::assert_admin(&env, &admin);
+
+        let params = get_risk_params(&env);
+        let now = env.ledger().timestamp();
+
+        let state = CircuitBreakerState {
+            is_active: true,
+            triggered_at: now,
+            reason: reason.clone(),
+            cooldown_until: now + params.circuit_breaker_cooldown,
+        };
+
+        set_circuit_breaker_state(&env, &state);
+
+        env.events().publish(
+            (Symbol::new(&env, "CircuitBreakerTriggered"),),
+            (reason, now),
+        );
+    }
+
+    // ---------------- INTERNAL HELPERS ----------------
+
+    fn assert_admin(env: &Env, caller: &Address) {
+        if let Err(err) = rbac::require_admin(env, caller) {
+            match err {
+                ContractError::RoleEscalationAttempt | ContractError::Unauthorized => {
+                    panic!("Unauthorized");
+                }
+                _ => panic!("Unauthorized"),
+            }
+        }
+    }
+
+    fn with_reentrancy_guard<F, R>(env: &Env, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        if is_reentrancy_locked(env) {
+            panic!("Reentrancy detected");
+        }
+        set_reentrancy_lock(env, true);
+        let result = f();
+        set_reentrancy_lock(env, false);
+        result
+    }
+
+    fn add_liquidity_internal(
+        env: &Env,
+        provider: &Address,
+        pool_id: u64,
+        amount_a: i128,
+        amount_b: i128,
+    ) -> i128 {
+        if amount_a <= 0 || amount_b <= 0 {
+            panic!("Amounts must be positive");
+        }
+
+        let mut pool = get_pool(env, pool_id);
+        let min_threshold = get_min_lp_token_threshold(env);
+
+        let lp_minted = if pool.lp_total_supply == 0 {
+            let lp_tokens = isqrt(amount_a * amount_b);
+            if lp_tokens < min_threshold {
+                panic!("Liquidity too small - minimum LP tokens required");
+            }
+            lp_tokens
+        } else {
+            let lp_a = ceil_div(amount_a * pool.lp_total_supply, pool.reserve_a);
+            let lp_b = ceil_div(amount_b * pool.lp_total_supply, pool.reserve_b);
+            let lp_tokens = if lp_a < lp_b { lp_a } else { lp_b };
+
+            if lp_tokens < min_threshold {
+                panic!("Liquidity too small - minimum LP tokens required");
+            }
+            lp_tokens
+        };
+
+        if lp_minted <= 0 {
+            panic!("Insufficient liquidity minted");
+        }
+
+        if pool.reserve_a > 0 && pool.reserve_b > 0 {
+            let pool_ratio = (pool.reserve_a * 10_000) / pool.reserve_b;
+            let deposit_ratio = (amount_a * 10_000) / amount_b;
+            let ratio_diff = if pool_ratio > deposit_ratio {
+                pool_ratio - deposit_ratio
+            } else {
+                deposit_ratio - pool_ratio
+            };
+            if ratio_diff > DEPOSIT_RATIO_TOLERANCE_BPS {
+                panic!("Deposit ratio deviates too much from pool ratio");
+            }
+        }
+
+        let contract_addr = env.current_contract_address();
+        TokenClient::new(env, &pool.token_a).transfer(provider, &contract_addr, &amount_a);
+        TokenClient::new(env, &pool.token_b).transfer(provider, &contract_addr, &amount_b);
+
+        pool.reserve_a += amount_a;
+        pool.reserve_b += amount_b;
+        pool.lp_total_supply += lp_minted;
+        set_pool(env, &pool);
+
+        let current_lp = get_lp_balance(env, pool_id, provider);
+        set_lp_balance(env, pool_id, provider, current_lp + lp_minted);
+        invalidate_query_cache(env, pool_id);
+
+        env.events().publish(
+            (Symbol::new(env, "LiquidityAdded"),),
+            (pool_id, provider.clone(), amount_a, amount_b, lp_minted),
+        );
+
+        lp_minted
+    }
+
+    fn remove_liquidity_internal(
+        env: &Env,
+        provider: &Address,
+        pool_id: u64,
+        lp_amount: i128,
+    ) -> (i128, i128) {
+        if lp_amount <= 0 {
+            panic!("LP amount must be positive");
+        }
+
+        let current_lp = get_lp_balance(env, pool_id, provider);
+        if current_lp < lp_amount {
+            panic!("Insufficient LP balance");
+        }
+
+        let mut pool = get_pool(env, pool_id);
+        if pool.lp_total_supply <= 0 {
+            panic!("Pool has no liquidity");
+        }
+
+        let remaining_lp = current_lp - lp_amount;
+        let min_threshold = get_min_lp_token_threshold(env);
+        if remaining_lp > 0 && remaining_lp < min_threshold {
+            panic!("Remaining LP tokens below minimum threshold");
+        }
+
+        let amount_a = floor_div(lp_amount * pool.reserve_a, pool.lp_total_supply);
+        let amount_b = floor_div(lp_amount * pool.reserve_b, pool.lp_total_supply);
+
+        if amount_a <= 0 || amount_b <= 0 {
+            panic!("Withdrawal amounts too small");
+        }
+
+        pool.reserve_a -= amount_a;
+        pool.reserve_b -= amount_b;
+        pool.lp_total_supply -= lp_amount;
+        set_pool(env, &pool);
+
+        set_lp_balance(env, pool_id, provider, remaining_lp);
+
+        let contract_addr = env.current_contract_address();
+        TokenClient::new(env, &pool.token_a).transfer(&contract_addr, provider, &amount_a);
+        TokenClient::new(env, &pool.token_b).transfer(&contract_addr, provider, &amount_b);
+
+        invalidate_query_cache(env, pool_id);
+
+        env.events().publish(
+            (Symbol::new(env, "LiquidityRemoved"),),
+            (pool_id, provider.clone(), amount_a, amount_b, lp_amount),
+        );
+
+        (amount_a, amount_b)
+    }
+
+    fn swap_internal(
+        env: &Env,
+        user: &Address,
+        pool_id: u64,
+        token_in: &Address,
+        amount_in: i128,
+        min_amount_out: i128,
+        collect_protocol_fee: bool,
+    ) -> i128 {
+        if amount_in <= 0 {
+            panic!("Input amount must be positive");
+        }
+
+        let mut pool = get_pool(env, pool_id);
+        if pool.reserve_a <= 0 || pool.reserve_b <= 0 {
+            panic!("Pool has no liquidity");
+        }
+
+        let (reserve_in, reserve_out, is_a_to_b) = if token_in == &pool.token_a {
+            (pool.reserve_a, pool.reserve_b, true)
+        } else if token_in == &pool.token_b {
+            (pool.reserve_b, pool.reserve_a, false)
+        } else {
+            panic!("Token not in pool");
+        };
+
+        let amount_out = get_amount_out(amount_in, reserve_in, reserve_out, pool.fee_bps);
+
+        if amount_out < min_amount_out {
+            panic!("Slippage tolerance exceeded");
+        }
+        if amount_out <= 0 {
+            panic!("Output amount is zero");
+        }
+
+        let contract_addr = env.current_contract_address();
+        let token_in_client = TokenClient::new(env, token_in);
+        token_in_client.transfer(user, &contract_addr, &amount_in);
+
+        let token_out = if is_a_to_b {
+            &pool.token_b
+        } else {
+            &pool.token_a
+        };
+
+        let protocol_share_bps = get_protocol_fee_share_bps(env);
+        let fee_amount = Self::calculate_swap_fee(amount_in, pool.fee_bps);
+        let protocol_fee = if collect_protocol_fee {
+            (fee_amount * protocol_share_bps as i128) / BPS_DENOMINATOR
+        } else {
+            0
+        };
+
+        if protocol_fee > 0 {
+            if let Some(collector) = get_governance_collector(env) {
+                token_in_client.transfer(&contract_addr, &collector, &protocol_fee);
+            }
+        }
+
+        let net_amount_in = amount_in - protocol_fee;
+        TokenClient::new(env, token_out).transfer(&contract_addr, user, &amount_out);
+
+        if is_a_to_b {
+            pool.reserve_a += net_amount_in;
+            pool.reserve_b -= amount_out;
+        } else {
+            pool.reserve_b += net_amount_in;
+            pool.reserve_a -= amount_out;
+        }
+        set_pool(env, &pool);
+        invalidate_query_cache(env, pool_id);
+
+        env.events().publish(
+            (Symbol::new(env, "Swapped"),),
+            (
+                pool_id,
+                user.clone(),
+                token_in.clone(),
+                amount_in,
+                amount_out,
+            ),
+        );
+
+        amount_out
+    }
+
+    fn calculate_swap_fee(amount_in: i128, fee_bps: u32) -> i128 {
+        (amount_in * fee_bps as i128) / BPS_DENOMINATOR
+    }
+
+    fn reserves_for_token(pool: &Pool, token_in: &Address) -> (i128, i128) {
+        if token_in == &pool.token_a {
+            (pool.reserve_a, pool.reserve_b)
+        } else if token_in == &pool.token_b {
+            (pool.reserve_b, pool.reserve_a)
+        } else {
+            panic!("Token not in pool");
+        }
+    }
+
+    fn reserves_for_pair(
+        pool: &Pool,
+        token_in: &Address,
+        token_out: &Address,
+    ) -> (i128, i128, bool) {
+        Self::validate_pool_tokens(pool, token_in, token_out);
+        if token_in == &pool.token_a && token_out == &pool.token_b {
+            (pool.reserve_a, pool.reserve_b, false)
+        } else {
+            (pool.reserve_b, pool.reserve_a, true)
+        }
+    }
+
+    fn validate_pool_tokens(pool: &Pool, token_a: &Address, token_b: &Address) {
+        let valid = (token_a == &pool.token_a && token_b == &pool.token_b)
+            || (token_a == &pool.token_b && token_b == &pool.token_a);
+        if !valid {
+            panic!("Token not in pool");
+        }
+    }
+
+    fn try_direct_route(
+        env: &Env,
+        pool_id: u64,
+        token_in: &Address,
+        token_out: &Address,
+        amount_in: i128,
+    ) -> Option<Route> {
+        let pool = get_pool(env, pool_id);
+
+        let (reserve_in, reserve_out) = if token_in == &pool.token_a && token_out == &pool.token_b {
+            (pool.reserve_a, pool.reserve_b)
+        } else if token_in == &pool.token_b && token_out == &pool.token_a {
+            (pool.reserve_b, pool.reserve_a)
+        } else {
+            return None;
+        };
+
+        if reserve_in <= 0 || reserve_out <= 0 {
+            return None;
+        }
+
+        let amount_out = get_amount_out(amount_in, reserve_in, reserve_out, pool.fee_bps);
+        if amount_out <= 0 {
+            return None;
+        }
+
+        let hop = Hop {
+            pool_id,
+            token_in: token_in.clone(),
+            token_out: token_out.clone(),
+            amount_in,
+            min_amount_out: amount_out * 95 / 100,
+        };
+
+        let mut hops = Vec::new(env);
+        hops.push_back(hop);
+
+        Some(Route {
+            token_in: token_in.clone(),
+            token_out: token_out.clone(),
+            amount_in,
+            amount_out,
+            total_fee_bps: pool.fee_bps,
+            hops,
+            created_at: env.ledger().timestamp(),
+        })
+    }
+
+    fn try_two_hop_route(
+        env: &Env,
+        pool_id_1: u64,
+        pool_id_2: u64,
+        token_in: &Address,
+        token_out: &Address,
+        amount_in: i128,
+    ) -> Option<Route> {
+        let pool_1 = get_pool(env, pool_id_1);
+        let pool_2 = get_pool(env, pool_id_2);
+
+        let intermediate_token =
+            Self::find_intermediate_token(&pool_1, &pool_2, token_in, token_out)?;
+
+        let route_1 =
+            Self::try_direct_route(env, pool_id_1, token_in, &intermediate_token, amount_in)?;
+        let route_2 = Self::try_direct_route(
+            env,
+            pool_id_2,
+            &intermediate_token,
+            token_out,
+            route_1.amount_out,
+        )?;
+
+        let mut hops = Vec::new(env);
+        hops.push_back(route_1.hops.get(0).unwrap().clone());
+        hops.push_back(route_2.hops.get(0).unwrap().clone());
+
+        Some(Route {
+            token_in: token_in.clone(),
+            token_out: token_out.clone(),
+            amount_in,
+            amount_out: route_2.amount_out,
+            total_fee_bps: pool_1.fee_bps + pool_2.fee_bps,
+            hops,
+            created_at: env.ledger().timestamp(),
+        })
+    }
+
+    fn find_intermediate_token(
+        pool_1: &Pool,
+        pool_2: &Pool,
+        token_in: &Address,
+        token_out: &Address,
+    ) -> Option<Address> {
+        let candidates = [pool_1.token_a.clone(), pool_1.token_b.clone()];
+        for t1 in candidates.iter() {
+            if t1 == token_in || t1 == token_out {
+                continue;
+            }
+            if t1 == &pool_2.token_a || t1 == &pool_2.token_b {
+                return Some(t1.clone());
+            }
+        }
+        None
+    }
+
+    fn check_trading_allowed(env: &Env) {
+        if is_trading_paused(env) {
+            panic!("Trading is currently paused");
+        }
+
+        if let Some(state) = get_circuit_breaker_state(env) {
+            if state.is_active {
+                let now = env.ledger().timestamp();
+                if now < state.cooldown_until {
+                    panic!("Circuit breaker is active");
+                } else {
+                    let mut expired_state = state;
+                    expired_state.is_active = false;
+                    set_circuit_breaker_state(env, &expired_state);
+                }
+            }
+        }
+    }
+
+    fn check_position_limits(env: &Env, user: &Address, token: &Address, amount: i128) {
+        let params = get_risk_params(env);
+        let current_position = Self::get_user_position_for_token(env, user, token);
+        let new_position = current_position + amount;
+
+        let user_total = Self::get_user_total_position(env, user);
+        if user_total + amount > params.max_position_per_user {
+            panic!("Exceeds maximum position per user");
+        }
+
+        if new_position > params.max_position_per_asset {
+            panic!("Exceeds maximum position per asset");
+        }
+
+        let concentration = Self::calculate_concentration_score(env, user);
+        if concentration > params.concentration_threshold_bps {
+            panic!("Portfolio concentration too high");
+        }
+    }
+
+    fn update_user_position(env: &Env, user: &Address, token: &Address, amount_change: i128) {
+        let current = Self::get_user_position_for_token(env, user, token);
+        let new_position = current + amount_change;
+
+        if new_position == 0 {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::UserPosition(user.clone(), token.clone()));
+        } else {
+            let position = UserPosition {
+                user: user.clone(),
+                token: token.clone(),
+                position_size: new_position,
+                last_updated: env.ledger().timestamp(),
+            };
+            set_user_position(env, user, token, &position);
+        }
+    }
+
+    fn get_user_position_for_token(env: &Env, user: &Address, token: &Address) -> i128 {
+        get_user_position(env, user, token)
+            .map(|p| p.position_size)
+            .unwrap_or(0)
+    }
+
+    fn get_user_total_position(env: &Env, user: &Address) -> i128 {
+        let pool_counter = get_pool_counter(env);
+        let mut total = 0i128;
+
+        for pool_id in 0..pool_counter {
+            let pool = get_pool(env, pool_id);
+            if let Some(pos) = get_user_position(env, user, &pool.token_a) {
+                total += pos.position_size.abs();
+            }
+            if let Some(pos) = get_user_position(env, user, &pool.token_b) {
+                total += pos.position_size.abs();
+            }
+        }
+
+        total
+    }
+
+    fn calculate_concentration_score(env: &Env, user: &Address) -> u32 {
+        let total = Self::get_user_total_position(env, user);
+        if total == 0 {
+            return 0;
+        }
+
+        let pool_counter = get_pool_counter(env);
+        let mut max_concentration = 0u32;
+
+        for pool_id in 0..pool_counter {
+            let pool = get_pool(env, pool_id);
+            if let Some(pos) = get_user_position(env, user, &pool.token_a) {
+                let concentration = (pos.position_size.abs() * 10_000) / total;
+                max_concentration = max_concentration.max(concentration as u32);
+            }
+            if let Some(pos) = get_user_position(env, user, &pool.token_b) {
+                let concentration = (pos.position_size.abs() * 10_000) / total;
+                max_concentration = max_concentration.max(concentration as u32);
+            }
+        }
+
+        max_concentration
+    }
+}

--- a/contracts/amm/src/math.rs
+++ b/contracts/amm/src/math.rs
@@ -1,0 +1,91 @@
+/// Integer square root using Newton's method (for no_std environments).
+pub fn isqrt(n: i128) -> i128 {
+    if n < 0 {
+        panic!("Cannot take square root of negative number");
+    }
+    if n == 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+/// Ceiling division: smallest integer >= a / b for positive numbers.
+pub fn ceil_div(a: i128, b: i128) -> i128 {
+    if b <= 0 {
+        panic!("Divisor must be positive");
+    }
+    if a < 0 {
+        panic!("Dividend must be non-negative for ceiling division");
+    }
+    (a + b - 1) / b
+}
+
+/// Floor division: largest integer <= a / b for positive numbers.
+pub fn floor_div(a: i128, b: i128) -> i128 {
+    if b <= 0 {
+        panic!("Divisor must be positive");
+    }
+    a / b
+}
+
+/// Constant-product swap output: amount_out given amount_in and fee.
+pub fn get_amount_out(amount_in: i128, reserve_in: i128, reserve_out: i128, fee_bps: u32) -> i128 {
+    if amount_in <= 0 || reserve_in <= 0 || reserve_out <= 0 {
+        return 0;
+    }
+    let fee_factor = 10_000 - fee_bps as i128;
+    let amount_in_after_fee = (amount_in * fee_factor) / 10_000;
+    let numerator = reserve_out * amount_in_after_fee;
+    let denominator = reserve_in + amount_in_after_fee;
+    numerator / denominator
+}
+
+/// Constant-product input required for a desired output (flash swap repayment).
+pub fn get_amount_in(amount_out: i128, reserve_in: i128, reserve_out: i128, fee_bps: u32) -> i128 {
+    if amount_out <= 0 || reserve_in <= 0 || reserve_out <= amount_out {
+        panic!("Invalid flash swap amount");
+    }
+    let numerator = reserve_in * amount_out * 10_000;
+    let denominator = (reserve_out - amount_out) * (10_000 - fee_bps as i128);
+    ceil_div(numerator, denominator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn isqrt_basic() {
+        assert_eq!(isqrt(0), 0);
+        assert_eq!(isqrt(1), 1);
+        assert_eq!(isqrt(4), 2);
+        assert_eq!(isqrt(10), 3);
+        assert_eq!(isqrt(100), 10);
+    }
+
+    #[test]
+    fn ceil_div_basic() {
+        assert_eq!(ceil_div(10, 3), 4);
+        assert_eq!(ceil_div(9, 3), 3);
+    }
+
+    #[test]
+    fn get_amount_out_matches_constant_product() {
+        let out = get_amount_out(1_000, 100_000, 100_000, 30);
+        assert!(out > 980);
+        assert!(out < 1_000);
+    }
+
+    #[test]
+    fn get_amount_in_rounds_up() {
+        let amount_in = get_amount_in(1_000, 100_000, 100_000, 30);
+        let out = get_amount_out(amount_in, 100_000, 100_000, 30);
+        assert!(out >= 999);
+    }
+}

--- a/contracts/amm/src/storage.rs
+++ b/contracts/amm/src/storage.rs
@@ -1,0 +1,181 @@
+use soroban_sdk::{Address, Env};
+
+use crate::types::{CircuitBreakerState, DataKey, Pool, RiskParams, UserPosition};
+
+/* ---------------- POOL COUNTER ---------------- */
+
+pub fn get_pool_counter(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::PoolCounter)
+        .unwrap_or(0)
+}
+
+pub fn set_pool_counter(env: &Env, counter: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PoolCounter, &counter);
+}
+
+/* ---------------- POOL DATA ---------------- */
+
+pub fn set_pool(env: &Env, pool: &Pool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Pool(pool.pool_id), pool);
+}
+
+pub fn get_pool(env: &Env, pool_id: u64) -> Pool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Pool(pool_id))
+        .expect("Pool not found")
+}
+
+/* ---------------- LP BALANCES ---------------- */
+
+pub fn get_lp_balance(env: &Env, pool_id: u64, provider: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::LpBalance(pool_id, provider.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_lp_balance(env: &Env, pool_id: u64, provider: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::LpBalance(pool_id, provider.clone()), &amount);
+}
+
+/* ---------------- QUERY CACHE INVALIDATION (Issue #215) ---------------- */
+
+pub fn invalidate_query_cache(env: &Env, pool_id: u64) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::PriceCache(pool_id));
+    env.storage()
+        .instance()
+        .remove(&DataKey::ReserveCache(pool_id));
+
+    env.events().publish(
+        (soroban_sdk::Symbol::new(env, "CacheInvalidated"),),
+        (pool_id, env.ledger().timestamp()),
+    );
+}
+
+/* ---------------- TRADING PAUSE & CIRCUIT BREAKER ---------------- */
+
+pub fn is_trading_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::TradingPaused)
+        .unwrap_or(false)
+}
+
+pub fn set_trading_paused(env: &Env, paused: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::TradingPaused, &paused);
+}
+
+pub fn get_circuit_breaker_state(env: &Env) -> Option<CircuitBreakerState> {
+    env.storage().instance().get(&DataKey::CircuitBreakerActive)
+}
+
+pub fn set_circuit_breaker_state(env: &Env, state: &CircuitBreakerState) {
+    env.storage()
+        .instance()
+        .set(&DataKey::CircuitBreakerActive, state);
+}
+
+/* ---------------- RISK MANAGEMENT ---------------- */
+
+pub fn get_risk_params(env: &Env) -> RiskParams {
+    env.storage()
+        .instance()
+        .get(&DataKey::RiskParams)
+        .unwrap_or(RiskParams {
+            max_position_per_user: 1_000_000_000,
+            max_position_per_asset: 10_000_000_000,
+            concentration_threshold_bps: 3000,
+            circuit_breaker_threshold_bps: 1500,
+            circuit_breaker_cooldown: 3600,
+            min_lp_token_threshold: 1000,
+        })
+}
+
+pub fn set_risk_params(env: &Env, params: &RiskParams) {
+    env.storage().instance().set(&DataKey::RiskParams, params);
+}
+
+pub fn get_user_position(env: &Env, user: &Address, token: &Address) -> Option<UserPosition> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserPosition(user.clone(), token.clone()))
+}
+
+pub fn set_user_position(env: &Env, user: &Address, token: &Address, position: &UserPosition) {
+    env.storage().persistent().set(
+        &DataKey::UserPosition(user.clone(), token.clone()),
+        position,
+    );
+}
+
+pub fn get_min_lp_token_threshold(env: &Env) -> i128 {
+    get_risk_params(env).min_lp_token_threshold
+}
+
+/* ---------------- FEE CONFIGURATION ---------------- */
+
+pub fn get_governance_collector(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::GovernanceCollector)
+}
+
+pub fn set_governance_collector(env: &Env, collector: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::GovernanceCollector, collector);
+}
+
+pub fn get_protocol_fee_share_bps(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ProtocolFeeShareBps)
+        .unwrap_or(0)
+}
+
+pub fn set_protocol_fee_share_bps(env: &Env, bps: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ProtocolFeeShareBps, &bps);
+}
+
+/* ---------------- LP REWARDS ---------------- */
+
+pub fn get_lp_reward_balance(env: &Env, pool_id: u64, token: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::LpRewardBalance(pool_id, token.clone()))
+        .unwrap_or(0)
+}
+
+pub fn set_lp_reward_balance(env: &Env, pool_id: u64, token: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::LpRewardBalance(pool_id, token.clone()), &amount);
+}
+
+/* ---------------- REENTRANCY ---------------- */
+
+pub fn is_reentrancy_locked(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReentrancyLock)
+        .unwrap_or(false)
+}
+
+pub fn set_reentrancy_lock(env: &Env, locked: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReentrancyLock, &locked);
+}

--- a/contracts/amm/src/test.rs
+++ b/contracts/amm/src/test.rs
@@ -1,0 +1,689 @@
+use super::*;
+use crate::storage::set_reentrancy_lock;
+use soroban_sdk::{contract, contractimpl, contracttype, testutils::Address as _, Address, Env};
+
+// ─── Mock Token ────────────────────────────────────────────────────
+
+#[contract]
+pub struct MockToken;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MockDataKey {
+    Balances(Address),
+}
+
+#[contractimpl]
+impl MockToken {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let key = MockDataKey::Balances(to.clone());
+        let current: i128 = env.storage().instance().get(&key).unwrap_or(0);
+        env.storage().instance().set(&key, &(current + amount));
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        let key = MockDataKey::Balances(id);
+        env.storage().instance().get(&key).unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        let from_key = MockDataKey::Balances(from.clone());
+        let from_bal: i128 = env.storage().instance().get(&from_key).unwrap_or(0);
+        assert!(from_bal >= amount, "Insufficient balance");
+        env.storage()
+            .instance()
+            .set(&from_key, &(from_bal - amount));
+
+        let to_key = MockDataKey::Balances(to.clone());
+        let to_bal: i128 = env.storage().instance().get(&to_key).unwrap_or(0);
+        env.storage().instance().set(&to_key, &(to_bal + amount));
+    }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+struct TestContext {
+    env: Env,
+    admin: Address,
+    amm_id: Address,
+    amm: AmmClient<'static>,
+    token_a: Address,
+    token_b: Address,
+}
+
+fn setup_env() -> TestContext {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let governance = Address::generate(&env);
+
+    let amm_id = env.register(Amm, ());
+    let amm = AmmClient::new(&env, &amm_id);
+
+    let token_a = env.register(MockToken, ());
+    let token_b = env.register(MockToken, ());
+
+    amm.initialize(&admin, &Some(governance));
+
+    TestContext {
+        env,
+        admin,
+        amm_id,
+        amm,
+        token_a,
+        token_b,
+    }
+}
+
+fn mint_tokens(env: &Env, token_id: &Address, to: &Address, amount: i128) {
+    MockTokenClient::new(env, token_id).mint(to, &amount);
+}
+
+fn create_funded_pool(ctx: &TestContext, amount_a: i128, amount_b: i128) -> (u64, Address) {
+    let provider = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, amount_a);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, amount_b);
+    ctx.amm
+        .add_liquidity(&provider, &pool_id, &amount_a, &amount_b);
+    (pool_id, provider)
+}
+
+// ─── Initialization & Pool Creation ──────────────────────────────
+
+#[test]
+fn test_initialize_and_create_pool() {
+    let ctx = setup_env();
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+    assert_eq!(pool_id, 0);
+
+    let pool = ctx.amm.get_pool(&pool_id);
+    assert_eq!(pool.token_a, ctx.token_a);
+    assert_eq!(pool.token_b, ctx.token_b);
+    assert_eq!(pool.fee_bps, 30);
+    assert_eq!(pool.reserve_a, 0);
+    assert_eq!(pool.reserve_b, 0);
+}
+
+#[test]
+#[should_panic(expected = "Token addresses must differ")]
+fn test_create_pool_same_tokens() {
+    let ctx = setup_env();
+    ctx.amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_a, &30);
+}
+
+#[test]
+#[should_panic(expected = "Fee cannot exceed 10%")]
+fn test_create_pool_excessive_fee() {
+    let ctx = setup_env();
+    ctx.amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &1001);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_create_pool_unauthorized() {
+    let ctx = setup_env();
+    let attacker = Address::generate(&ctx.env);
+    ctx.amm
+        .create_pool(&attacker, &ctx.token_a, &ctx.token_b, &30);
+}
+
+// ─── Liquidity ─────────────────────────────────────────────────────
+
+#[test]
+fn test_add_liquidity_initial() {
+    let ctx = setup_env();
+    let provider = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 20_000);
+
+    let lp = ctx.amm.add_liquidity(&provider, &pool_id, &10_000, &20_000);
+    assert!(lp > 0);
+
+    let pool = ctx.amm.get_pool(&pool_id);
+    assert_eq!(pool.reserve_a, 10_000);
+    assert_eq!(pool.reserve_b, 20_000);
+    assert_eq!(pool.lp_total_supply, lp);
+    assert_eq!(ctx.amm.get_lp_balance(&pool_id, &provider), lp);
+}
+
+#[test]
+fn test_add_liquidity_subsequent() {
+    let ctx = setup_env();
+    let provider1 = Address::generate(&ctx.env);
+    let provider2 = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider1, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider1, 10_000);
+    let lp1 = ctx
+        .amm
+        .add_liquidity(&provider1, &pool_id, &10_000, &10_000);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider2, 5_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider2, 5_000);
+    let lp2 = ctx.amm.add_liquidity(&provider2, &pool_id, &5_000, &5_000);
+
+    assert_eq!(lp2, lp1 / 2);
+}
+
+#[test]
+fn test_remove_liquidity() {
+    let ctx = setup_env();
+    let provider = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 10_000);
+    let lp = ctx.amm.add_liquidity(&provider, &pool_id, &10_000, &10_000);
+
+    let (out_a, out_b) = ctx.amm.remove_liquidity(&provider, &pool_id, &(lp / 2));
+    assert_eq!(out_a, 5_000);
+    assert_eq!(out_b, 5_000);
+
+    let pool = ctx.amm.get_pool(&pool_id);
+    assert_eq!(pool.reserve_a, 5_000);
+    assert_eq!(pool.reserve_b, 5_000);
+}
+
+// ─── Swaps ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_swap_and_quote() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+
+    let quoted = ctx.amm.quote_swap(&pool_id, &ctx.token_a, &1_000);
+    assert!(quoted > 0);
+    assert!(quoted < 1_000);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+    let out = ctx.amm.swap(&user, &pool_id, &ctx.token_a, &1_000, &0);
+    assert_eq!(out, quoted);
+
+    let user_b = MockTokenClient::new(&ctx.env, &ctx.token_b).balance(&user);
+    assert_eq!(user_b, out);
+}
+
+#[test]
+#[should_panic(expected = "Slippage tolerance exceeded")]
+fn test_swap_slippage_protection() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &1_000, &999);
+}
+
+#[test]
+fn test_get_price() {
+    let ctx = setup_env();
+    let provider = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 20_000);
+    ctx.amm.add_liquidity(&provider, &pool_id, &10_000, &20_000);
+
+    assert_eq!(ctx.amm.get_price(&pool_id, &ctx.token_a), 2_000_000);
+    assert_eq!(ctx.amm.get_price(&pool_id, &ctx.token_b), 500_000);
+}
+
+#[test]
+fn test_fee_distribution_via_reserves() {
+    let ctx = setup_env();
+    let provider = Address::generate(&ctx.env);
+    let user = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 100_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 100_000);
+    let lp = ctx
+        .amm
+        .add_liquidity(&provider, &pool_id, &100_000, &100_000);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 10_000);
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &10_000, &0);
+
+    let (out_a, out_b) = ctx.amm.remove_liquidity(&provider, &pool_id, &lp);
+    assert!(out_a > 100_000);
+    assert!(out_b < 100_000);
+    assert!(out_a + out_b > 200_000);
+}
+
+#[test]
+fn test_protocol_fee_to_governance() {
+    let ctx = setup_env();
+    let governance = Address::generate(&ctx.env);
+    ctx.amm.set_fee_config(&ctx.admin, &governance, &2_000);
+
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 10_000);
+
+    let gov_before = MockTokenClient::new(&ctx.env, &ctx.token_a).balance(&governance);
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &10_000, &0);
+    let gov_after = MockTokenClient::new(&ctx.env, &ctx.token_a).balance(&governance);
+
+    assert!(gov_after > gov_before);
+}
+
+// ─── Flash Swap ────────────────────────────────────────────────────
+
+#[test]
+fn test_flash_swap() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let borrower = Address::generate(&ctx.env);
+
+    let max_in = 10_000i128;
+    mint_tokens(&ctx.env, &ctx.token_a, &borrower, max_in);
+
+    let bal_before = MockTokenClient::new(&ctx.env, &ctx.token_b).balance(&borrower);
+    let amount_in = ctx.amm.flash_swap(
+        &borrower,
+        &pool_id,
+        &ctx.token_b,
+        &1_000,
+        &ctx.token_a,
+        &max_in,
+    );
+    let bal_after = MockTokenClient::new(&ctx.env, &ctx.token_b).balance(&borrower);
+
+    assert!(amount_in > 0);
+    assert_eq!(bal_after - bal_before, 1_000);
+
+    let pool = ctx.amm.get_pool(&pool_id);
+    assert!(pool.reserve_a > 100_000);
+    assert!(pool.reserve_b < 100_000);
+}
+
+#[test]
+#[should_panic(expected = "Flash swap repayment exceeds max_amount_in")]
+fn test_flash_swap_max_amount_in() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let borrower = Address::generate(&ctx.env);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &borrower, 1);
+    ctx.amm
+        .flash_swap(&borrower, &pool_id, &ctx.token_b, &1_000, &ctx.token_a, &1);
+}
+
+// ─── LP Rewards ────────────────────────────────────────────────────
+
+#[test]
+fn test_lp_rewards_deposit_and_claim() {
+    let ctx = setup_env();
+    let (pool_id, provider) = create_funded_pool(&ctx, 10_000, 10_000);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &ctx.admin, 5_000);
+    ctx.amm
+        .deposit_lp_rewards(&ctx.admin, &pool_id, &ctx.token_a, &5_000);
+
+    let (pending_a, pending_b) = ctx.amm.get_pending_lp_rewards(&pool_id, &provider);
+    assert_eq!(pending_a, 5_000);
+    assert_eq!(pending_b, 0);
+
+    let (claimed_a, claimed_b) = ctx.amm.claim_lp_rewards(&provider, &pool_id);
+    assert_eq!(claimed_a, 5_000);
+    assert_eq!(claimed_b, 0);
+
+    let (pending_a2, _) = ctx.amm.get_pending_lp_rewards(&pool_id, &provider);
+    assert_eq!(pending_a2, 0);
+}
+
+// ─── Multi-hop ─────────────────────────────────────────────────────
+
+#[test]
+fn test_find_best_route_direct() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+
+    let route = ctx
+        .amm
+        .find_best_route(&ctx.token_a, &ctx.token_b, &1_000, &2);
+
+    assert_eq!(route.token_in, ctx.token_a);
+    assert_eq!(route.token_out, ctx.token_b);
+    assert_eq!(route.hops.len(), 1);
+    assert_eq!(route.hops.get(0).unwrap().pool_id, pool_id);
+}
+
+#[test]
+fn test_execute_multi_hop_swap_two_hop() {
+    let ctx = setup_env();
+    let token_c = ctx.env.register(MockToken, ());
+    let provider = Address::generate(&ctx.env);
+    let user = Address::generate(&ctx.env);
+
+    let pool_ab = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+    let pool_bc = ctx.amm.create_pool(&ctx.admin, &ctx.token_b, &token_c, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 100_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 200_000);
+    ctx.amm
+        .add_liquidity(&provider, &pool_ab, &100_000, &200_000);
+
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 100_000);
+    mint_tokens(&ctx.env, &token_c, &provider, 100_000);
+    ctx.amm
+        .add_liquidity(&provider, &pool_bc, &100_000, &100_000);
+
+    let route = ctx.amm.find_best_route(&ctx.token_a, &token_c, &1_000, &3);
+    let hop_count = route.hops.len();
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+
+    let output = ctx.amm.execute_multi_hop_swap(&user, &route, &0);
+    assert!(output > 0);
+    assert_eq!(hop_count, 2);
+}
+
+#[test]
+fn test_multiple_pools() {
+    let ctx = setup_env();
+    let token_c = ctx.env.register(MockToken, ());
+
+    let pool_0 = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+    let pool_1 = ctx.amm.create_pool(&ctx.admin, &ctx.token_a, &token_c, &50);
+
+    assert_eq!(pool_0, 0);
+    assert_eq!(pool_1, 1);
+    assert_eq!(ctx.amm.get_pool(&pool_0).fee_bps, 30);
+    assert_eq!(ctx.amm.get_pool(&pool_1).fee_bps, 50);
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_double_initialize_panics() {
+    let ctx = setup_env();
+    ctx.amm.initialize(&ctx.admin, &None);
+}
+
+#[test]
+#[should_panic(expected = "No valid route found")]
+fn test_find_best_route_no_route() {
+    let ctx = setup_env();
+    let token_c = ctx.env.register(MockToken, ());
+
+    // Pool exists for A-B only; no path to token_c.
+    let _pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    ctx.amm.find_best_route(&ctx.token_a, &token_c, &1_000, &3);
+}
+
+#[test]
+fn test_execute_multi_hop_swap_single_hop() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+
+    let route = ctx
+        .amm
+        .find_best_route(&ctx.token_a, &ctx.token_b, &1_000, &2);
+    assert_eq!(route.hops.len(), 1);
+    assert_eq!(route.hops.get(0).unwrap().pool_id, pool_id);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+    let quoted = ctx.amm.quote_swap(&pool_id, &ctx.token_a, &1_000);
+    let output = ctx.amm.execute_multi_hop_swap(&user, &route, &0);
+
+    assert_eq!(output, quoted);
+    assert!(output > 0);
+    assert!(output < 1_000);
+}
+
+#[test]
+#[should_panic(expected = "Reentrancy detected")]
+fn test_reentrancy_guard_blocks_swap() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+
+    // Simulate a nested entry while the reentrancy lock is held.
+    ctx.env.as_contract(&ctx.amm_id, || {
+        set_reentrancy_lock(&ctx.env, true);
+    });
+
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &1_000, &0);
+}
+
+#[test]
+#[should_panic(expected = "Insufficient pool liquidity for flash swap")]
+fn test_flash_swap_insufficient_liquidity() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let borrower = Address::generate(&ctx.env);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &borrower, 200_000);
+    ctx.amm.flash_swap(
+        &borrower,
+        &pool_id,
+        &ctx.token_b,
+        &200_000,
+        &ctx.token_a,
+        &500_000,
+    );
+}
+
+#[test]
+fn test_get_pending_lp_rewards_without_lp() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 10_000, 10_000);
+    let outsider = Address::generate(&ctx.env);
+
+    let (pending_a, pending_b) = ctx.amm.get_pending_lp_rewards(&pool_id, &outsider);
+    assert_eq!(pending_a, 0);
+    assert_eq!(pending_b, 0);
+}
+
+// ─── Admin & Risk ──────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Trading is currently paused")]
+fn test_swap_while_paused() {
+    let ctx = setup_env();
+    ctx.amm.pause_trading(&ctx.admin);
+
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &1_000, &0);
+}
+
+#[test]
+fn test_pause_resume_trading() {
+    let ctx = setup_env();
+    ctx.amm.pause_trading(&ctx.admin);
+    ctx.amm.resume_trading(&ctx.admin);
+
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+
+    let output = ctx.amm.swap(&user, &pool_id, &ctx.token_a, &1_000, &0);
+    assert!(output > 0);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_unauthorized_pause_trading() {
+    let ctx = setup_env();
+    let attacker = Address::generate(&ctx.env);
+    ctx.amm.pause_trading(&attacker);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_old_admin_cannot_resume() {
+    let ctx = setup_env();
+    let new_admin = Address::generate(&ctx.env);
+
+    ctx.amm.set_admin(&ctx.admin, &new_admin);
+    ctx.amm.pause_trading(&new_admin);
+    ctx.amm.resume_trading(&ctx.admin);
+}
+
+#[test]
+#[should_panic(expected = "Circuit breaker is active")]
+fn test_swap_while_circuit_breaker_active() {
+    let ctx = setup_env();
+    ctx.amm.trigger_circuit_breaker(
+        &ctx.admin,
+        &soroban_sdk::String::from_str(&ctx.env, "Market volatility"),
+    );
+
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 1_000);
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &1_000, &0);
+}
+
+#[test]
+fn test_risk_parameters() {
+    let ctx = setup_env();
+    let params = RiskParams {
+        max_position_per_user: 1_000_000,
+        max_position_per_asset: 5_000_000,
+        concentration_threshold_bps: 2500,
+        circuit_breaker_threshold_bps: 1000,
+        circuit_breaker_cooldown: 1800,
+        min_lp_token_threshold: 500,
+    };
+
+    ctx.amm.set_risk_parameters(&ctx.admin, &params);
+    let user = Address::generate(&ctx.env);
+    let (total_pos, concentration, threshold) = ctx.amm.get_risk_metrics(&user);
+    assert_eq!(total_pos, 0);
+    assert_eq!(concentration, 0);
+    assert_eq!(threshold, 2500);
+}
+
+// ─── Rounding Protection ───────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Liquidity too small")]
+fn test_minimum_lp_token_threshold() {
+    let ctx = setup_env();
+    let params = RiskParams {
+        max_position_per_user: 1_000_000_000,
+        max_position_per_asset: 10_000_000_000,
+        concentration_threshold_bps: 3000,
+        circuit_breaker_threshold_bps: 1500,
+        circuit_breaker_cooldown: 3600,
+        min_lp_token_threshold: 10_000,
+    };
+    ctx.amm.set_risk_parameters(&ctx.admin, &params);
+
+    let provider = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 100);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 100);
+    ctx.amm.add_liquidity(&provider, &pool_id, &100, &100);
+}
+
+#[test]
+#[should_panic(expected = "Deposit ratio deviates too much")]
+fn test_liquidity_ratio_protection() {
+    let ctx = setup_env();
+    let params = RiskParams {
+        max_position_per_user: 1_000_000_000,
+        max_position_per_asset: 10_000_000_000,
+        concentration_threshold_bps: 3000,
+        circuit_breaker_threshold_bps: 1500,
+        circuit_breaker_cooldown: 3600,
+        min_lp_token_threshold: 10,
+    };
+    ctx.amm.set_risk_parameters(&ctx.admin, &params);
+
+    let provider = Address::generate(&ctx.env);
+    let provider2 = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 10_000);
+    ctx.amm.add_liquidity(&provider, &pool_id, &10_000, &10_000);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider2, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider2, 100);
+    ctx.amm.add_liquidity(&provider2, &pool_id, &10_000, &100);
+}
+
+#[test]
+#[should_panic(expected = "Remaining LP tokens below minimum threshold")]
+fn test_remove_liquidity_dust_protection() {
+    let ctx = setup_env();
+    let params = RiskParams {
+        max_position_per_user: 1_000_000_000,
+        max_position_per_asset: 10_000_000_000,
+        concentration_threshold_bps: 3000,
+        circuit_breaker_threshold_bps: 1500,
+        circuit_breaker_cooldown: 3600,
+        min_lp_token_threshold: 1000,
+    };
+    ctx.amm.set_risk_parameters(&ctx.admin, &params);
+
+    let provider = Address::generate(&ctx.env);
+    let pool_id = ctx
+        .amm
+        .create_pool(&ctx.admin, &ctx.token_a, &ctx.token_b, &30);
+
+    mint_tokens(&ctx.env, &ctx.token_a, &provider, 10_000);
+    mint_tokens(&ctx.env, &ctx.token_b, &provider, 10_000);
+    let lp = ctx.amm.add_liquidity(&provider, &pool_id, &10_000, &10_000);
+
+    ctx.amm.remove_liquidity(&provider, &pool_id, &(lp - 500));
+}
+
+#[test]
+fn test_constant_product_invariant_after_swap() {
+    let ctx = setup_env();
+    let (pool_id, _) = create_funded_pool(&ctx, 100_000, 100_000);
+    let user = Address::generate(&ctx.env);
+
+    let pool_before = ctx.amm.get_pool(&pool_id);
+    let k_before = pool_before.reserve_a * pool_before.reserve_b;
+
+    mint_tokens(&ctx.env, &ctx.token_a, &user, 5_000);
+    ctx.amm.swap(&user, &pool_id, &ctx.token_a, &5_000, &0);
+
+    let pool_after = ctx.amm.get_pool(&pool_id);
+    let k_after = pool_after.reserve_a * pool_after.reserve_b;
+
+    // k should increase due to fees staying in the pool.
+    assert!(k_after >= k_before);
+}

--- a/contracts/amm/src/types.rs
+++ b/contracts/amm/src/types.rs
@@ -1,0 +1,139 @@
+use soroban_sdk::{contracttype, Address, String, Vec};
+
+/// Storage keys for the AMM contract.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Pool counter for generating unique pool IDs.
+    PoolCounter,
+    /// Pool data keyed by pool ID.
+    Pool(u64),
+    /// LP token balance: (pool_id, provider).
+    LpBalance(u64, Address),
+    /// Cached price data for pool (Issue #215).
+    PriceCache(u64),
+    /// Cached reserve data for pool (Issue #215).
+    ReserveCache(u64),
+    /// Timestamp of last cache invalidation (Issue #215).
+    LastCacheInvalidation,
+    /// Trading pause state.
+    TradingPaused,
+    /// Circuit breaker state.
+    CircuitBreakerActive,
+    /// Risk parameters for position limits.
+    RiskParams,
+    /// User position tracking.
+    UserPosition(Address, Address),
+    /// Minimum LP token threshold.
+    MinLpTokenThreshold,
+    /// Governance fee collector address.
+    GovernanceCollector,
+    /// Protocol fee share in basis points (portion of swap fees sent to governance).
+    ProtocolFeeShareBps,
+    /// Accumulated LP reward balances per pool: (pool_id, token).
+    LpRewardBalance(u64, Address),
+    /// Reentrancy guard.
+    ReentrancyLock,
+}
+
+/// Represents a liquidity pool for a token pair.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Pool {
+    /// Unique pool identifier.
+    pub pool_id: u64,
+    /// Address of token A.
+    pub token_a: Address,
+    /// Address of token B.
+    pub token_b: Address,
+    /// Reserve of token A in the pool.
+    pub reserve_a: i128,
+    /// Reserve of token B in the pool.
+    pub reserve_b: i128,
+    /// Total supply of LP tokens for this pool.
+    pub lp_total_supply: i128,
+    /// Swap fee in basis points (e.g. 30 = 0.30%).
+    pub fee_bps: u32,
+}
+
+/// Represents a single hop in a multi-hop swap route.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Hop {
+    /// Pool ID for this hop.
+    pub pool_id: u64,
+    /// Token input for this hop.
+    pub token_in: Address,
+    /// Token output for this hop.
+    pub token_out: Address,
+    /// Expected input amount for this hop.
+    pub amount_in: i128,
+    /// Minimum output amount (slippage protection).
+    pub min_amount_out: i128,
+}
+
+/// Represents a complete multi-hop swap route.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Route {
+    /// Token being swapped from.
+    pub token_in: Address,
+    /// Token being swapped to.
+    pub token_out: Address,
+    /// Input amount.
+    pub amount_in: i128,
+    /// Expected output amount.
+    pub amount_out: i128,
+    /// Total fee in basis points.
+    pub total_fee_bps: u32,
+    /// Sequence of hops to execute.
+    pub hops: Vec<Hop>,
+    /// Route creation timestamp.
+    pub created_at: u64,
+}
+
+/// Risk management parameters for position limits.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RiskParams {
+    /// Maximum position size per user.
+    pub max_position_per_user: i128,
+    /// Maximum position size per asset.
+    pub max_position_per_asset: i128,
+    /// Portfolio concentration threshold (basis points).
+    pub concentration_threshold_bps: u32,
+    /// Circuit breaker threshold for price moves (basis points).
+    pub circuit_breaker_threshold_bps: u32,
+    /// Circuit breaker cooldown period in seconds.
+    pub circuit_breaker_cooldown: u64,
+    /// Minimum LP token minting threshold.
+    pub min_lp_token_threshold: i128,
+}
+
+/// User position tracking for risk management.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UserPosition {
+    /// User address.
+    pub user: Address,
+    /// Token address.
+    pub token: Address,
+    /// Current position size.
+    pub position_size: i128,
+    /// Last updated timestamp.
+    pub last_updated: u64,
+}
+
+/// Circuit breaker state.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CircuitBreakerState {
+    /// Whether circuit breaker is currently active.
+    pub is_active: bool,
+    /// Timestamp when circuit breaker was triggered.
+    pub triggered_at: u64,
+    /// Reason for triggering.
+    pub reason: String,
+    /// Cooldown expiry timestamp.
+    pub cooldown_until: u64,
+}

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -34,6 +34,7 @@ pub enum ModuleId {
     Waitlist = 21,
     MultisigWaitlist = 22,
     BridgeManager = 23,
+    Amm = 24,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds Soroban AMM module at `contracts/amm` with constant-product (`x * y = k`) liquidity pools
- Implements LP token mint/burn, swaps with slippage protection, multi-hop routing, flash swaps, and LP reward claiming
- Integrates `stellai_lib` RBAC for admin functions and configurable governance fee routing
- Adds `ModuleId::Amm` to the shared crate

## Implementation details
- **Liquidity:** `add_liquidity`, `remove_liquidity` with proportional LP accounting and dust/ratio guards
- **Trading:** `swap`, `quote_swap`, `find_best_route`, `execute_multi_hop_swap`
- **Flash swaps:** Atomic borrow + repay with `max_amount_in` validation
- **Fees:** Swap fees accrue to LPs via reserves; optional protocol share sent to governance collector
- **Rewards:** `deposit_lp_rewards`, `claim_lp_rewards`, `get_pending_lp_rewards`
- **Admin:** Pause/resume trading, circuit breaker, risk parameters, fee config

## Test plan
- [x] `cargo test -p amm` — 38 unit tests passing
- [x] `cargo clippy -p amm --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo build --release --target wasm32-unknown-unknown -p amm`
- [x] Liquidity add/remove, swap math, slippage, fees, flash swap, multi-hop, RBAC, reentrancy, edge cases

## Notes
- LP tokens use internal accounting (not a separate fungible token contract)
- Multi-token support via multiple 2-token pools + multi-hop routing
- Flash swaps are atomic (borrow and repay in the same call)

Closes #293